### PR TITLE
ci: add workflow to validate Renovate configs

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,33 @@
+---
+name: Validate Renovate Config
+
+on:
+  push:
+    paths:
+      - default.json
+      - org-inherited-config.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - default.json
+      - org-inherited-config.json
+      - .github/workflows/renovate-config-lint.yaml
+  workflow_dispatch: null
+
+permissions:
+  contents: read
+
+jobs:
+  validate-renovate-config:
+    name: Validate Renovate configs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate Renovate configs
+        run: |
+          docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
+            renovate-config-validator --strict default.json org-inherited-config.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/renovate-config-lint.yaml` that runs `renovate-config-validator` from the official `renovate/renovate` Docker image against `default.json` and `org-inherited-config.json`.
- Uses `--strict` so warnings fail the build — this is an org-wide inherited config, so warnings shouldn't slip through.
- Triggers on push/PR that changes either config file or the workflow itself, plus `workflow_dispatch` for manual runs.
- Modeled on [Netcracker/qubership-profiler-agent's renovate-config-lint.yaml](https://github.com/Netcracker/qubership-profiler-agent/blob/main/.github/workflows/renovate-config-lint.yaml), adapted for this repo's two non-standard filenames and matching the project's existing workflow style (YAML doc-marker, SHA-pinned actions, `persist-credentials: false`, `permissions: contents: read`).

## Test plan
- [x] Ran the same Docker command locally — both files pass: `Config validated successfully against 2 file(s)`.
- [x] CI run on this PR passes the new `Validate Renovate Config` job.
- [ ] Confirm path filters trigger correctly (job runs when `org-inherited-config.json` changes; skipped on unrelated changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)