### PR TITLE
feat: exempt in-house packages from the release-age delay

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -19,6 +19,24 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/**"],
       "groupName": "actions org"
+    },
+    {
+      "description": ["Skip the release-age delay for in-house Maven libraries"],
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["/^com\\.netcracker[.:]/", "/^org\\.qubership[.:]/"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Skip the release-age delay for in-house Docker images"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/netcracker/**"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Skip the release-age delay for in-house Go modules"],
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/Netcracker/**"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## What

Add `packageRules` to `org-inherited-config.json` that set `minimumReleaseAge: "0 days"` for in-house dependencies:

- Maven groups `com.netcracker` and `org.qubership` (anchored regex on the `groupId:artifactId` package name, scoped to `matchDatasources: ["maven"]`).
- Docker images under `ghcr.io/netcracker/**`.
- Go modules under `github.com/Netcracker/**` (`matchDatasources: ["go"]`), covering major-version suffixes such as `/v2`.

## Why

The org-wide `minimumReleaseAge: "7 days"` makes every update wait out a week-long cooldown. After we release our own libraries, PRs that bump those libraries in platform services stall for a week, which blocks rolling the updates into our services.

The new rules sit after the base config, so by last-one-wins they override the global delay only for our own packages. Everything else keeps the 7-day cooldown, and security PRs still ship immediately via `vulnerabilityAlerts`. The rules only change the cooldown — they set no `groupName`, so each dependency still gets its own PR.

## How to verify

- CI: the `Validate Renovate configs` workflow runs `renovate-config-validator --strict`.
- Locally: `docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict org-inherited-config.json` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)