### PR TITLE
feat: add APM Renovate preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ To opt a repository out entirely, set `"enabled": false` (or remove the Mend ins
 
 [`default.json`](./default.json) is a small explicit preset (`extends: ["config:recommended"]`) provided for the rare case where a repository wants to opt into a named preset via `"extends": ["github>Netcracker/renovate-config"]`. It is **not** what powers the automatic inheritance described above — that comes from `org-inherited-config.json`.
 
+## `apm.json` preset
+
+[`apm.json`](./apm.json) detects APM package references in `apm.yml` files. It updates package references pinned to
+GitHub release tags, package references pinned to immutable Git SHAs with a source-ref comment, mutable package
+references that still need a SHA pin, and marketplace entries that use `source`, `subdir`, and `ref`.
+
+Use it from a repository-local config:
+
+```json
+{
+  "extends": ["github>Netcracker/renovate-config:apm"]
+}
+```
+
 ## Changing the org-wide config
 
 Open a PR against `org-inherited-config.json`. Once merged to `main`, the next Renovate run on any repository in the org picks up the new values automatically.

--- a/apm.json
+++ b/apm.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Detect APM package dependencies in apm.yml files"],
+  "customManagers": [
+    {
+      "description": "Update APM dependencies pinned to GitHub release tags.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
+      "matchStrings": [
+        "(?<depPrefix>-\\s+)(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9_.-]+)?)(?<depSuffix>\\s*(?:#.*)?)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depTypeTemplate": "apm",
+      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{depName}}}@{{{newValue}}}{{{depSuffix}}}"
+    },
+    {
+      "description": "Update APM dependencies pinned to immutable Git refs with a mutable source ref comment.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
+      "matchStrings": [
+        "(?<depPrefix>-\\s+)(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))#(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[^\\s#]+)"
+      ],
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{packageName}}}.git",
+      "depTypeTemplate": "apm",
+      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{depName}}}#{{{newDigest}}}  # {{{currentValue}}}"
+    },
+    {
+      "description": "Pin APM dependencies that still reference a mutable Git ref directly.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
+      "matchStrings": [
+        "(?<depPrefix>-\\s+)(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))#(?<currentValue>[A-Za-z_./-][A-Za-z0-9_./-]*)"
+      ],
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{packageName}}}.git",
+      "depTypeTemplate": "apm",
+      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{depName}}}#{{{newDigest}}}  # {{{currentValue}}}"
+    },
+    {
+      "description": "Update marketplace APM package entries pinned to immutable Git refs.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
+      "matchStrings": [
+        "(?<depPrefix>source:\\s+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n\\s+subdir:\\s+(?<apmSubdir>[^\\n]+)\\n\\s+ref:\\s+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[^\\s#]+)"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "{{{packageName}}}/{{{apmSubdir}}}",
+      "packageNameTemplate": "https://github.com/{{{packageName}}}.git",
+      "depTypeTemplate": "apm",
+      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{newDigest}}}  # {{{currentValue}}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": ["Group APM package updates together"],
+      "matchDepTypes": ["apm"],
+      "groupName": "apm packages",
+      "labels": ["dependencies", "apm"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Why

APM package references in `apm.yml` files are updated manually today. Repositories need a shared Renovate preset that can track APM release tags, commit SHA pins, mutable branch refs that still need pinning, and marketplace `source` / `subdir` / `ref` entries.

This PR is required before Netcracker/qubership-ai-packages can enable `github>Netcracker/renovate-config:apm` in its repository-local Renovate config.

## What

- Add `apm.json` with regex custom managers for APM package references.
- Group extracted APM dependencies into `apm packages` PRs with `dependencies` and `apm` labels.
- Resolve Git refs through `https://github.com/<owner>/<repo>.git` so `git-refs` can update branch and tag SHAs.
- Document the new preset in `README.md`.

## How to verify

- `renovate-config-validator apm.json`
- `renovate-config-validator default.json`
- `renovate-config-validator org-inherited-config.json`
- Tested against Netcracker/qubership-ai-packages with a temporary merged config; Renovate extracted APM refs and found the expected updates matching Netcracker/qubership-ai-packages#46.
