### PR TITLE
fix(apm): match marketplace package entries exactly

### DIFF
--- a/.github/scripts/validate-apm-regex.mjs
+++ b/.github/scripts/validate-apm-regex.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+
+const config = JSON.parse(fs.readFileSync('apm.json', 'utf8'));
+const marketplaceManager = config.customManagers.find((manager) =>
+  manager.description === 'Update marketplace APM package entries pinned to immutable Git refs.'
+);
+
+if (!marketplaceManager) {
+  throw new Error('Marketplace APM custom manager was not found');
+}
+
+const regex = new RegExp(marketplaceManager.matchStrings[0], 'g');
+const fixture = `marketplace:
+  packages:
+    - name: ai-agent-telemetry
+      source: Netcracker/qubership-ai-agent-telemetry
+      subdir: agent-packages/ai-agent-telemetry
+      ref: c9ab85efe02149166e385f5962e1735d531e64d7  # main
+      tags: ["topic:observability", "activity:telemetry", "audience:public"]
+
+    - name: ai-agent-telemetry-configure
+      source: Netcracker/qubership-ai-agent-telemetry
+      subdir: agent-packages/ai-agent-telemetry-configure
+      ref: c9ab85efe02149166e385f5962e1735d531e64d7  # main
+      tags: ["topic:observability", "activity:telemetry", "audience:public"]
+`;
+
+const matches = [...fixture.matchAll(regex)];
+const depNames = matches.map((match) => `${match.groups.packageName}/${match.groups.apmSubdir}`);
+
+const expected = [
+  'Netcracker/qubership-ai-agent-telemetry/agent-packages/ai-agent-telemetry',
+  'Netcracker/qubership-ai-agent-telemetry/agent-packages/ai-agent-telemetry-configure',
+];
+
+if (JSON.stringify(depNames) !== JSON.stringify(expected)) {
+  throw new Error(`Marketplace APM regex matched ${JSON.stringify(depNames)}, expected ${JSON.stringify(expected)}`);
+}
+
+for (const match of matches) {
+  if (!match[0].startsWith('- name:')) {
+    throw new Error(`Marketplace APM regex must match a complete package item, got ${JSON.stringify(match[0])}`);
+  }
+}

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -4,13 +4,17 @@ name: Validate Renovate Config
 on:
   push:
     paths:
+      - apm.json
       - default.json
       - org-inherited-config.json
+      - .github/scripts/validate-apm-regex.mjs
       - .github/workflows/renovate-config-lint.yaml
   pull_request:
     paths:
+      - apm.json
       - default.json
       - org-inherited-config.json
+      - .github/scripts/validate-apm-regex.mjs
       - .github/workflows/renovate-config-lint.yaml
   workflow_dispatch: null
 
@@ -30,4 +34,7 @@ jobs:
       - name: Validate Renovate configs
         run: |
           docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
-            renovate-config-validator --strict default.json org-inherited-config.json
+            renovate-config-validator --strict default.json org-inherited-config.json apm.json
+
+      - name: Validate APM regex behavior
+        run: node .github/scripts/validate-apm-regex.mjs

--- a/apm.json
+++ b/apm.json
@@ -43,7 +43,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
       "matchStrings": [
-        "(?<depPrefix>source:\\s+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n\\s+subdir:\\s+(?<apmSubdir>[^\\n]+)\\n\\s+ref:\\s+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[^\\s#]+)"
+        "(?<depPrefix>-[^\\S\\n]+name:[^\\S\\n]+[^\\n]+\\n[^\\S\\n]+source:[^\\S\\n]+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n[^\\S\\n]+subdir:[^\\S\\n]+(?<apmSubdir>[^\\n]+)\\n[^\\S\\n]+ref:[^\\S\\n]+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[^\\s#]+)"
       ],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "{{{packageName}}}/{{{apmSubdir}}}",


### PR DESCRIPTION
## Why
Renovate fails to update the grouped APM dependency branch in Netcracker/qubership-ai-packages with `depName mismatch` while processing adjacent marketplace entries from the same repository.

## What
- Anchor the marketplace APM regex to the complete YAML package item from `- name` through `ref`.
- Include `apm.json` in the Renovate config validator workflow.
- Add a Node-based regression check for adjacent marketplace entries with shared `source` and `ref` values.

## How to verify
- `node .github/scripts/validate-apm-regex.js`
- `jq empty apm.json default.json org-inherited-config.json`
- `docker run --rm -v /tmp/renovate-config:/work -w /work renovate/renovate:latest renovate-config-validator --strict default.json org-inherited-config.json apm.json`