### PR TITLE
fix(apm): avoid grouping regex package updates

### DIFF
--- a/.github/scripts/validate-apm-regex.mjs
+++ b/.github/scripts/validate-apm-regex.mjs
@@ -1,9 +1,18 @@
 import fs from 'node:fs';
 
 const config = JSON.parse(fs.readFileSync('apm.json', 'utf8'));
+const apmPackageRule = config.packageRules.find((rule) => rule.matchDepTypes?.includes('apm'));
 const marketplaceManager = config.customManagers.find((manager) =>
   manager.description === 'Update marketplace APM package entries pinned to immutable Git refs.'
 );
+
+if (!apmPackageRule) {
+  throw new Error('APM package rule was not found');
+}
+
+if ('groupName' in apmPackageRule) {
+  throw new Error('APM package rule must not group custom regex updates because Renovate validates them by depIndex');
+}
 
 if (!marketplaceManager) {
   throw new Error('Marketplace APM custom manager was not found');

--- a/apm.json
+++ b/apm.json
@@ -54,9 +54,8 @@
   ],
   "packageRules": [
     {
-      "description": ["Group APM package updates together"],
+      "description": ["Configure APM package updates"],
       "matchDepTypes": ["apm"],
-      "groupName": "apm packages",
       "labels": ["dependencies", "apm"],
       "pinDigests": true
     }


### PR DESCRIPTION
## Why

Renovate still fails to create `renovate/apm-packages` for `Netcracker/qubership-ai-packages` after the marketplace regex was anchored to full YAML items. The July 10, 2026 10:59 log shows the updated preset is loaded, but Renovate fails during `autoReplace` validation with `depName mismatch`: it starts with `ai-agent-telemetry` and validates against `ai-agent-telemetry-configure`.

The failing branch groups custom regex APM updates from multiple `apm.yml` files and regex custom managers. Renovate validates custom-regex replacements by `depIndex`, so this grouped branch can point validation at a different dependency after replacement.

## What

- Stop assigning `groupName` to APM updates.
- Keep APM labels and `pinDigests` unchanged.
- Add a regression check so the APM package rule does not reintroduce grouping.

## How to verify

- `node .github/scripts/validate-apm-regex.mjs`
- `jq empty apm.json default.json org-inherited-config.json`
- `docker run --rm -v /tmp/renovate-config:/work -w /work renovate/renovate:latest renovate-config-validator --strict default.json org-inherited-config.json apm.json`
- `docker run --rm -e RUN_LOCAL=true -e DEFAULT_BRANCH=origin/main -e VALIDATE_ALL_CODEBASE=false -e VALIDATE_JAVASCRIPT_ES=true -e VALIDATE_JSON=true -v /tmp/renovate-config:/tmp/lint ghcr.io/super-linter/super-linter:slim-v8.5.0`