### PR TITLE
fix(apm): unify Git ref dependency handling

### DIFF
--- a/.github/scripts/validate-apm-regex.mjs
+++ b/.github/scripts/validate-apm-regex.mjs
@@ -2,11 +2,8 @@ import fs from 'node:fs';
 
 const config = JSON.parse(fs.readFileSync('apm.json', 'utf8'));
 const apmPackageRule = config.packageRules.find((rule) => rule.matchDepTypes?.includes('apm'));
-const digestManager = config.customManagers.find((manager) =>
-  manager.description === 'Update APM dependencies pinned to immutable Git refs with a mutable source ref comment.'
-);
-const mutableRefManager = config.customManagers.find((manager) =>
-  manager.description === 'Pin APM dependencies that still reference a mutable Git ref directly.'
+const gitRefManager = config.customManagers.find((manager) =>
+  manager.description === 'Pin and update APM dependencies that reference Git refs.'
 );
 const marketplaceManager = config.customManagers.find((manager) =>
   manager.description === 'Update marketplace APM package entries pinned to immutable Git refs.'
@@ -20,12 +17,8 @@ if (apmPackageRule.groupName !== 'apm packages') {
   throw new Error('APM package rule must group package updates');
 }
 
-if (!digestManager) {
-  throw new Error('Immutable Git ref APM custom manager was not found');
-}
-
-if (!mutableRefManager) {
-  throw new Error('Mutable Git ref APM custom manager was not found');
+if (!gitRefManager) {
+  throw new Error('Git ref APM custom manager was not found');
 }
 
 if (!marketplaceManager) {
@@ -88,6 +81,7 @@ function replaceDigest(manager, content, dependencyIndex, newDigest) {
       packageName: match.groups.packageName,
       currentValue: match.groups.currentValue,
       currentDigest: match.groups.currentDigest,
+      indentation: match.groups.indentation,
       newDigest,
     };
     replacement = manager.autoReplaceStringTemplate.replaceAll(
@@ -112,7 +106,7 @@ function assertDependencyCountPreserved(manager, content, dependencyIndex) {
   }
 }
 
-assertDependencyCountPreserved(digestManager, digestFixture, 1);
+assertDependencyCountPreserved(gitRefManager, digestFixture, 1);
 assertDependencyCountPreserved(marketplaceManager, fixture, 0);
 
 const supportedTemplateFields = new Set([
@@ -129,7 +123,7 @@ const supportedTemplateFields = new Set([
   'registryUrl',
   'versioning',
 ]);
-const mutableTemplateFields = [...mutableRefManager.autoReplaceStringTemplate.matchAll(/\{\{\{([^}]+)}}}/g)].map(
+const mutableTemplateFields = [...gitRefManager.autoReplaceStringTemplate.matchAll(/\{\{\{([^}]+)}}}/g)].map(
   (match) => match[1]
 );
 const unsupportedTemplateFields = mutableTemplateFields.filter((field) => !supportedTemplateFields.has(field));
@@ -142,13 +136,13 @@ const mutableFixture = `dependencies:
   apm:
     - Netcracker/example/agent-packages/example#main
 `;
-const mutableRegex = new RegExp(mutableRefManager.matchStrings[0], 'g');
+const mutableRegex = new RegExp(gitRefManager.matchStrings[0], 'g');
 const mutableMatch = [...mutableFixture.matchAll(mutableRegex)][0];
 const mutableValues = {
   ...mutableMatch.groups,
-  newDigest: 'b3a0a1582ab3728efdd52c6765f51a6bc75d51af',
+  newDigest: '4594b3b9d09c066ec549f4b6cee2eb1266c7f948',
 };
-const pinnedDependency = mutableRefManager.autoReplaceStringTemplate.replaceAll(
+const pinnedDependency = gitRefManager.autoReplaceStringTemplate.replaceAll(
   /\{\{\{([^}]+)}}}/g,
   (_, field) => mutableValues[field] ?? ''
 );
@@ -156,6 +150,6 @@ const pinnedFixture = `${mutableFixture.slice(0, mutableMatch.index)}${pinnedDep
   mutableMatch.index + mutableMatch[0].length
 )}`;
 
-if ([...pinnedFixture.matchAll(new RegExp(digestManager.matchStrings[0], 'g'))].length !== 1) {
-  throw new Error('Pinned mutable Git ref must be detected as an immutable Git ref');
+if ([...pinnedFixture.matchAll(new RegExp(gitRefManager.matchStrings[0], 'g'))].length !== 1) {
+  throw new Error('Pinned mutable Git ref must still be detected by the manager that pinned it');
 }

--- a/apm.json
+++ b/apm.json
@@ -14,22 +14,11 @@
       "depTypeTemplate": "apm"
     },
     {
-      "description": "Update APM dependencies pinned to immutable Git refs with a mutable source ref comment.",
+      "description": "Pin and update APM dependencies that reference Git refs.",
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
       "matchStrings": [
-        "(?<depPrefix>-\\s+)(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))#(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[^\\s#]+)"
-      ],
-      "datasourceTemplate": "git-refs",
-      "packageNameTemplate": "https://github.com/{{{packageName}}}.git",
-      "depTypeTemplate": "apm"
-    },
-    {
-      "description": "Pin APM dependencies that still reference a mutable Git ref directly.",
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
-      "matchStrings": [
-        "(?<indentation>[\\t ]*)-\\s+(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))#(?<currentValue>[A-Za-z_./-][A-Za-z0-9_./-]*)"
+        "(?<indentation>[\\t ]*)-\\s+(?<depName>(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/(?<apmSubdir>[^\\s#@]+))#(?:(?<currentDigest>[0-9a-f]{40})\\s+#\\s+)?(?<currentValue>[A-Za-z_./-][A-Za-z0-9_./-]*)"
       ],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{packageName}}}.git",


### PR DESCRIPTION
## Why

Renovate validates a regex replacement by re-extracting the dependency with the manager that performed the update. Separate managers for mutable and immutable Git refs break this contract: after pinning `#branch` to `#<digest> # branch`, the mutable-ref manager can no longer find the dependency and reports `fewer deps than expected`.

The unified manager was tested with Mend-hosted Renovate in `Netcracker/qubership-ai-packages`. It processed 28 grouped APM upgrades, updated five files, and created `renovate/apm-packages` at `31e84717477ba090c4064c00c167a6c0a3d75d0f` without an update failure.

## What

- Replace the separate mutable and immutable Git ref managers with one manager that detects both forms.
- Keep the existing APM grouping and replacement format.
- Fix the regression fixture to use a numeric-leading digest and require re-extraction by the same manager.

## How to verify

- `node .github/scripts/validate-apm-regex.mjs`
- `jq empty apm.json default.json org-inherited-config.json`
- `renovate-config-validator --strict default.json org-inherited-config.json apm.json`
- Super-Linter for changed JavaScript and JSON files