### PR TITLE
feat: add reusable Renovate capability presets

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -1,0 +1,267 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const presetNames = [
+  'base',
+  'github-actions',
+  'go',
+  'go-tidy',
+  'netcracker-dependencies',
+  'annotated-versions',
+  'grafana-plugins',
+  'graylog-plugins',
+];
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function readFixture(path) {
+  return fs.readFileSync(`tests/fixtures/${path}`, 'utf8');
+}
+
+function findRule(config, description) {
+  const rule = config.packageRules?.find((candidate) => {
+    const value = Array.isArray(candidate.description) ? candidate.description.join(' ') : candidate.description;
+    return value?.includes(description);
+  });
+  assert.ok(rule, `Package rule not found: ${description}`);
+  return rule;
+}
+
+function compileManager(manager) {
+  return manager.matchStrings.map((matchString) => new RegExp(matchString, 'g'));
+}
+
+function managerMatchesPath(manager, path) {
+  return manager.managerFilePatterns.some((pattern) => {
+    assert.match(pattern, /^\/.+\/$/, `Test runner does not support non-regex file pattern: ${pattern}`);
+    return new RegExp(pattern.slice(1, -1)).test(path);
+  });
+}
+
+function extract(manager, content) {
+  return compileManager(manager).flatMap((regex) => [...content.matchAll(regex)].map((match) => match.groups));
+}
+
+function render(template, values) {
+  return template
+    .replaceAll(/\{\{\{replace '\^v' '' ([^}]+)}}}/g, (_, field) => (values[field] ?? '').replace(/^v/, ''))
+    .replaceAll(/\{\{\{([^}]+)}}}/g, (_, field) => values[field] ?? '');
+}
+
+function assertBasePolicy(config) {
+  assert.deepEqual(config.extends, ['config:best-practices', 'schedule:weekly']);
+  assert.deepEqual(config.labels, ['dependencies']);
+  assert.equal(config.semanticCommits, 'enabled');
+  assert.equal(config.semanticCommitType, 'chore');
+  assert.equal(config.semanticCommitScope, 'deps');
+  assert.equal('automerge' in config, false, 'base.json must not configure automerge');
+}
+
+function assertGitHubActionsPolicy(config) {
+  const thirdParty = findRule(config, 'Group third-party GitHub Actions');
+  const netcracker = findRule(config, 'Group Netcracker GitHub Actions');
+  const majorThirdParty = findRule(config, 'Group third-party GitHub Actions major updates separately');
+  const majorNetcracker = findRule(config, 'Group Netcracker GitHub Actions major updates separately');
+  const nonMajorUpdateTypes = ['minor', 'patch', 'pin', 'digest', 'pinDigest'];
+  assert.deepEqual(thirdParty.matchManagers, ['github-actions']);
+  assert.deepEqual(thirdParty.matchPackageNames, ['!Netcracker/**', '!netcracker/**']);
+  assert.deepEqual(netcracker.matchPackageNames, ['Netcracker/**', 'netcracker/**']);
+  for (const rule of [thirdParty, netcracker]) {
+    assert.deepEqual(rule.matchUpdateTypes, nonMajorUpdateTypes);
+  }
+  for (const rule of [majorThirdParty, majorNetcracker]) {
+    assert.deepEqual(rule.matchUpdateTypes, ['major']);
+  }
+}
+
+function assertGoPolicy(config) {
+  assert.equal(JSON.stringify(config).includes('gomodTidy'), false, 'go.json must not enable gomodTidy');
+  for (const description of [
+    'Group Kubernetes Go modules',
+    'Group OpenTelemetry Go modules',
+    'Group Prometheus Go modules',
+    'Group Go toolchain updates',
+  ]) {
+    findRule(config, description);
+  }
+  assert.equal(config.packageRules.length, 4, 'go.json must not group unrelated Go dependencies');
+  const openTelemetry = findRule(config, 'Group OpenTelemetry Go modules');
+  assert.deepEqual(openTelemetry.matchPackageNames, [
+    'go.opentelemetry.io/**',
+    'github.com/open-telemetry/**',
+  ]);
+}
+
+function assertGoTidyPolicy(config) {
+  const rule = findRule(config, 'Run go mod tidy after Go module updates');
+  assert.deepEqual(rule.matchManagers, ['gomod']);
+  assert.deepEqual(rule.postUpdateOptions, ['gomodTidy']);
+}
+
+function assertNetcrackerPolicy(config) {
+  const expected = [
+    ['Group Netcracker GitHub Actions', 'matchManagers', ['github-actions']],
+    ['Group Netcracker Docker images', 'matchDatasources', ['docker']],
+    ['Group Netcracker Go modules', 'matchManagers', ['gomod']],
+    ['Group Netcracker Maven artifacts', 'matchManagers', ['maven']],
+  ];
+  for (const [description, matcher, values] of expected) {
+    const rule = findRule(config, description);
+    assert.deepEqual(rule[matcher], values);
+    assert.equal(rule.minimumReleaseAge, '0 days');
+    assert.ok(rule.groupName);
+  }
+  assert.deepEqual(findRule(config, 'Group Netcracker GitHub Actions').matchUpdateTypes, [
+    'minor',
+    'patch',
+    'pin',
+    'digest',
+    'pinDigest',
+  ]);
+  const majorActions = findRule(config, 'Group major Netcracker GitHub Actions updates separately');
+  assert.deepEqual(majorActions.matchUpdateTypes, ['major']);
+  assert.equal(majorActions.minimumReleaseAge, '0 days');
+}
+
+function assertNoAutomerge(configs) {
+  for (const [name, config] of Object.entries(configs)) {
+    assert.equal('automerge' in config, false, `${name}.json must not configure automerge`);
+    for (const rule of config.packageRules ?? []) {
+      assert.equal('automerge' in rule, false, `${name}.json package rules must not configure automerge`);
+    }
+  }
+}
+
+function assertAnnotatedVersions(config) {
+  const fixtures = [
+    [
+      'annotated-versions/Dockerfile',
+      'Update annotated Docker ARG version values.',
+      'alpine',
+      '3.22.0',
+      undefined,
+      undefined,
+    ],
+    [
+      'annotated-versions/values.yaml',
+      'Update annotated next-line YAML and template version values.',
+      'prometheus/prometheus',
+      'v3.5.0',
+      undefined,
+      undefined,
+    ],
+    [
+      'annotated-versions/config.yaml.tmpl',
+      'Update annotated next-line YAML and template version values.',
+      'ghcr.io/netcracker/example',
+      '1.2.3',
+      'ghcr.io/netcracker/example',
+      'docker',
+    ],
+    [
+      'annotated-versions/Makefile',
+      'Update annotated go install versions in Makefiles.',
+      'golang.org/x/tools/gopls',
+      'v0.19.1',
+      undefined,
+      'semver',
+    ],
+    [
+      'annotated-versions/monitoring/templates/grafana-image.tpl',
+      'Update annotated image versions in Helm print templates.',
+      'quay.io/grafana-operator/grafana-operator',
+      'v5.22.2',
+      undefined,
+      undefined,
+    ],
+    [
+      'annotated-versions/logging/templates/graylog-image.tpl',
+      'Update annotated image versions in Helm print templates.',
+      'graylog/graylog',
+      '5.2.12',
+      undefined,
+      undefined,
+    ],
+    [
+      'annotated-versions/logging/values.yaml',
+      'Update annotated commented image versions in YAML files.',
+      'Netcracker/qubership-fluentd',
+      '1.19.2-2',
+      undefined,
+      'loose',
+    ],
+    [
+      'annotated-versions/logging/fluent.conf',
+      'Update annotated version directives in configuration files.',
+      'Netcracker/qubership-fluentd',
+      '1.19.2-2',
+      undefined,
+      'loose',
+    ],
+  ];
+  for (const [path, managerDescription, depName, currentValue, packageName, versioning] of fixtures) {
+    const matchingManagers = config.customManagers.filter((manager) => managerMatchesPath(manager, path));
+    const matches = matchingManagers.flatMap((manager) =>
+      extract(manager, readFixture(path)).map((dependency) => ({ dependency, manager }))
+    );
+    assert.equal(matches.length, 1, `${path} must contain exactly one annotated dependency`);
+    assert.equal(matches[0].manager.description, managerDescription, `${path} matched the wrong custom manager`);
+    assert.equal(matches[0].dependency.depName, depName);
+    assert.equal(matches[0].dependency.currentValue, currentValue);
+    assert.equal(matches[0].dependency.packageName, packageName);
+    assert.equal(matches[0].dependency.versioning, versioning);
+  }
+}
+
+function assertGrafanaPlugins(config) {
+  const manager = config.customManagers[0];
+  const dependencies = extract(manager, readFixture('grafana-plugins/plugins.list'));
+  assert.deepEqual(
+    dependencies.map(({ depName, currentValue }) => [depName, currentValue]),
+    [
+      ['retrodaredevil-wildgraphql-datasource', '1.6.1'],
+      ['victoriametrics-metrics-datasource', '0.25.1'],
+    ]
+  );
+  assert.ok(config.customDatasources?.['grafana-plugins']);
+  assert.equal(manager.datasourceTemplate, 'custom.grafana-plugins');
+}
+
+function assertGraylogPlugins(config) {
+  const manager = config.customManagers[0];
+  assert.equal(manager.depTypeTemplate, 'graylog-plugin');
+  assert.deepEqual(findRule(config, 'Group Graylog plugin updates').matchDepTypes, ['graylog-plugin']);
+  const fixture = readFixture('graylog-plugins/plugins.list');
+  const dependencies = extract(manager, fixture);
+  assert.equal(dependencies.length, 2);
+  assert.deepEqual(
+    dependencies.map(({ packageName, currentValue }) => [packageName, currentValue]),
+    [
+      ['graylog-labs/graylog-plugin-metrics-reporter', '3.0.0'],
+      ['irgendwr/TelegramAlert', 'v2.3.7'],
+    ]
+  );
+
+  const updates = ['4.0.0', 'v2.4.0'];
+  for (const [index, groups] of dependencies.entries()) {
+    const newValue = updates[index];
+    const replacement = render(manager.autoReplaceStringTemplate, { ...groups, newValue });
+    assert.ok(replacement.includes(`/download/${newValue}/`));
+    assert.ok(replacement.endsWith(`-${newValue.replace(/^v/, '')}.jar`));
+  }
+}
+
+const configs = Object.fromEntries(presetNames.map((name) => [name, readJson(`${name}.json`)]));
+assertBasePolicy(configs.base);
+assertGitHubActionsPolicy(configs['github-actions']);
+assertGoPolicy(configs.go);
+assertGoTidyPolicy(configs['go-tidy']);
+assertNetcrackerPolicy(configs['netcracker-dependencies']);
+assertAnnotatedVersions(configs['annotated-versions']);
+assertGrafanaPlugins(configs['grafana-plugins']);
+assertGraylogPlugins(configs['graylog-plugins']);
+assertNoAutomerge(configs);
+
+console.log(`Validated ${presetNames.length} capability presets and their extraction fixtures.`);

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -134,6 +134,13 @@ function assertNoAutomerge(configs) {
   }
 }
 
+function assertRepositoryPolicy(config) {
+  assert.ok(
+    config.extends?.includes(':ignoreModulesAndTests'),
+    'renovate.json must ignore test and fixture dependency files'
+  );
+}
+
 function assertAnnotatedVersions(config) {
   const fixtures = [
     [
@@ -173,6 +180,14 @@ function assertAnnotatedVersions(config) {
       'Update annotated image versions in Helm print templates.',
       'quay.io/grafana-operator/grafana-operator',
       'v5.22.2',
+      undefined,
+      undefined,
+    ],
+    [
+      'annotated-versions/helm-comment.tpl',
+      'Update annotated image versions in Helm print templates.',
+      'otel/opentelemetry-collector-contrib',
+      '0.131.0',
       undefined,
       undefined,
     ],
@@ -254,6 +269,7 @@ function assertGraylogPlugins(config) {
 }
 
 const configs = Object.fromEntries(presetNames.map((name) => [name, readJson(`${name}.json`)]));
+assertRepositoryPolicy(readJson('renovate.json'));
 assertBasePolicy(configs.base);
 assertGitHubActionsPolicy(configs['github-actions']);
 assertGoPolicy(configs.go);

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -29,46 +29,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate shareable Renovate configs
+      - name: Validate shared Renovate configs
         run: |
-          configs=(
-            annotated-versions.json
-            apm.json
-            base.json
-            default.json
-            github-actions.json
-            go-tidy.json
-            go.json
-            grafana-plugins.json
-            graylog-plugins.json
-            netcracker-dependencies.json
-          )
+          configs=()
+          for config in ./*.json; do
+            if [[ "$config" != "./renovate.json" ]]; then
+              configs+=("${config#./}")
+            fi
+          done
           docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
             renovate-config-validator --strict --no-global "${configs[@]}"
 
-      - name: Validate inherited Renovate config
+      - name: Validate repository Renovate config
         run: |
           docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
-            renovate-config-validator --strict --no-global org-inherited-config.json
-
-      - name: Parse Renovate config JSON
-        run: |
-          configs=(
-            annotated-versions.json
-            apm.json
-            base.json
-            default.json
-            github-actions.json
-            go-tidy.json
-            go.json
-            grafana-plugins.json
-            graylog-plugins.json
-            netcracker-dependencies.json
-            org-inherited-config.json
-          )
-          node -e \
-            'const fs = require("node:fs"); for (const file of process.argv.slice(1)) JSON.parse(fs.readFileSync(file));' \
-            "${configs[@]}"
+            renovate-config-validator --strict --no-global renovate.json
 
       - name: Validate capability preset behavior
         run: node .github/scripts/test-presets.mjs

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -4,18 +4,16 @@ name: Validate Renovate Config
 on:
   push:
     paths:
-      - apm.json
-      - default.json
-      - org-inherited-config.json
-      - .github/scripts/validate-apm-regex.mjs
+      - "*.json"
+      - .github/scripts/*.mjs
       - .github/workflows/renovate-config-lint.yaml
+      - tests/fixtures/**
   pull_request:
     paths:
-      - apm.json
-      - default.json
-      - org-inherited-config.json
-      - .github/scripts/validate-apm-regex.mjs
+      - "*.json"
+      - .github/scripts/*.mjs
       - .github/workflows/renovate-config-lint.yaml
+      - tests/fixtures/**
   workflow_dispatch: null
 
 permissions:
@@ -31,10 +29,49 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate Renovate configs
+      - name: Validate shareable Renovate configs
+        run: |
+          configs=(
+            annotated-versions.json
+            apm.json
+            base.json
+            default.json
+            github-actions.json
+            go-tidy.json
+            go.json
+            grafana-plugins.json
+            graylog-plugins.json
+            netcracker-dependencies.json
+          )
+          docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
+            renovate-config-validator --strict --no-global "${configs[@]}"
+
+      - name: Validate inherited Renovate config
         run: |
           docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest \
-            renovate-config-validator --strict default.json org-inherited-config.json apm.json
+            renovate-config-validator --strict --no-global org-inherited-config.json
+
+      - name: Parse Renovate config JSON
+        run: |
+          configs=(
+            annotated-versions.json
+            apm.json
+            base.json
+            default.json
+            github-actions.json
+            go-tidy.json
+            go.json
+            grafana-plugins.json
+            graylog-plugins.json
+            netcracker-dependencies.json
+            org-inherited-config.json
+          )
+          node -e \
+            'const fs = require("node:fs"); for (const file of process.argv.slice(1)) JSON.parse(fs.readFileSync(file));' \
+            "${configs[@]}"
+
+      - name: Validate capability preset behavior
+        run: node .github/scripts/test-presets.mjs
 
       - name: Validate APM regex behavior
         run: node .github/scripts/validate-apm-regex.mjs

--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
 # Renovate Configuration
 
-This repository hosts the **shared Renovate configuration** used across all repositories in the `Netcracker` GitHub organization.
+This repository hosts the **shared Renovate configuration** used across all repositories in the `Netcracker` GitHub
+organization.
 
 ## How it is applied
 
-The Mend Renovate App is configured at the organization level with **Inherited Config** enabled. On every run, Mend reads [`org-inherited-config.json`](./org-inherited-config.json) from this repository (defaults: `inheritConfigRepoName=renovate-config`, `inheritConfigFileName=org-inherited-config.json`) and merges it as the base layer for every repository in the org.
+The Mend Renovate App is configured at the organization level with **Inherited Config** enabled. On every run, Mend
+reads [`org-inherited-config.json`](./org-inherited-config.json) from this repository and merges it as the base layer
+for every repository in the organization.
 
-**You do not need to add anything to your repository to receive these defaults.** Any existing `renovate.json` / `renovate.json5` in your repo is layered on top and can override the inherited values.
+**You do not need to add anything to your repository to receive these defaults.** Any existing `renovate.json` or
+`renovate.json5` in your repository is layered on top and can override the inherited values.
 
 ## What the inherited config does
 
-- Extends [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) — recommended baseline plus Dependency Dashboard, config migration PRs, dev-dependency pinning, and SHA-pinned GitHub Actions with semver hints.
-- `minimumReleaseAge: "7 days"` — delays updates until a release has been public for one week, so freshly-published broken or compromised versions are not proposed.
-- `internalChecksFilter: "strict"` — when the newest version is still inside the 7-day window, Renovate proposes the latest version that has already matured rather than opening a PR marked "pending".
-- `osvVulnerabilityAlerts: true` — enables the OSV.dev source for CVEs in addition to GitHub Security Advisories.
-- **Security updates bypass the 7-day delay.** The `vulnerabilityAlerts` block opens vulnerability PRs immediately (`minimumReleaseAge: null`, `prCreation: "immediate"`, `schedule: ["at any time"]`).
-- **Go toolchain and official `golang.org/x/*` updates bypass the 7-day delay** (`minimumReleaseAge: "0 days"`). The Go toolchain is matched by the `golang-version` datasource (the `go` and `toolchain` directives in `go.mod`); the official libraries are matched by the `golang.org/x/**` package names on the `go` datasource. Ordinary Go module dependencies keep the standard 7-day delay.
+- Extends [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices), which provides
+  the recommended baseline, Dependency Dashboard, config migrations, dev-dependency pinning, and SHA-pinned GitHub
+  Actions with semver hints.
+- `minimumReleaseAge: "7 days"` delays updates until a release has been public for one week.
+- `internalChecksFilter: "strict"` proposes the latest mature version while a newer release is still inside the
+  release-age window.
+- `osvVulnerabilityAlerts: true` enables OSV.dev in addition to GitHub Security Advisories.
+- Security updates bypass the seven-day delay. The `vulnerabilityAlerts` block opens vulnerability PRs immediately.
+- Go toolchain and official `golang.org/x/*` updates bypass the delay. Other Go module dependencies keep the standard
+  seven-day delay.
 - Groups all `actions/*` GitHub Actions updates into a single PR titled `actions org`.
 
 ## Overriding for a specific repository
 
-If a repository needs to deviate from the org defaults, add a `renovate.json` in that repository. Repo-local settings win on conflicts. Example:
+If a repository needs to deviate from the organization defaults, add a `renovate.json` in that repository.
+Repository-local settings win on conflicts. Example:
 
 ```json
 {
@@ -33,7 +42,43 @@ To opt a repository out entirely, set `"enabled": false` (or remove the Mend ins
 
 ## `default.json` preset
 
-[`default.json`](./default.json) is a small explicit preset (`extends: ["config:recommended"]`) provided for the rare case where a repository wants to opt into a named preset via `"extends": ["github>Netcracker/renovate-config"]`. It is **not** what powers the automatic inheritance described above — that comes from `org-inherited-config.json`.
+[`default.json`](./default.json) is a small explicit preset (`extends: ["config:recommended"]`) for a repository that
+opts into `"github>Netcracker/renovate-config"`. The automatic inheritance described above comes from
+`org-inherited-config.json`.
+
+## Capability presets
+
+Capability presets are additive and opt-in. Compose only the capabilities that a repository needs instead of extending
+a team-specific preset:
+
+- `base` applies an explicit best-practices baseline, weekly schedule, dependency label, and semantic commit settings.
+- `github-actions` groups third-party and Netcracker actions separately, with major updates in separate groups.
+- `go` groups Kubernetes, OpenTelemetry, Prometheus, and Go toolchain updates. It does not group unrelated modules.
+- `go-tidy` runs `go mod tidy` after Go module updates.
+- `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
+- `annotated-versions` updates explicitly annotated Docker, YAML, template, and Makefile values.
+- `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`.
+- `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.
+- `apm` updates APM package references in `apm.yml`.
+
+The `go-tidy` preset is separate because `gomodTidy` can make changes to `go.mod` and `go.sum` that are unrelated to
+the dependency Renovate is updating. Enable it only when those broader module-file changes are acceptable.
+
+For example, a Go repository that uses annotated tool versions can compose these presets:
+
+```json
+{
+  "extends": [
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "github>Netcracker/renovate-config:annotated-versions"
+  ]
+}
+```
+
+Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository decision.
 
 ## `apm.json` preset
 
@@ -51,7 +96,8 @@ Use it from a repository-local config:
 
 ## Changing the org-wide config
 
-Open a PR against `org-inherited-config.json`. Once merged to `main`, the next Renovate run on any repository in the org picks up the new values automatically.
+Open a PR against `org-inherited-config.json`. Once merged to `main`, the next Renovate run on any repository in the
+organization picks up the new values automatically.
 
 ## References
 

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -23,7 +23,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/).+\\.tpl$/"],
       "matchStrings": [
-        "\\{\\{- /\\* # renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))? \\*/ -\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{- print \\\"[^\\\"\\r\\n]+:(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)\\\" -\\}\\}"
+        "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)\\\"[\\t ]*-?\\}\\}"
       ]
     },
     {

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Update explicitly annotated version values in supported text files"],
+  "customManagers": [
+    {
+      "description": "Update annotated Docker ARG version values.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)(?:Dockerfile|Containerfile)(?:\\.[^/]+)?$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*ARG [A-Za-z_][A-Za-z0-9_]*[ =][\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
+      ]
+    },
+    {
+      "description": "Update annotated next-line YAML and template version values.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).+\\.(?:ya?ml|ya?ml\\.tmpl|tmpl)$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*[A-Za-z_][A-Za-z0-9_.-]*:[\\t ]*[\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
+      ]
+    },
+    {
+      "description": "Update annotated image versions in Helm print templates.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).+\\.tpl$/"],
+      "matchStrings": [
+        "\\{\\{- /\\* # renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))? \\*/ -\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{- print \\\"[^\\\"\\r\\n]+:(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)\\\" -\\}\\}"
+      ]
+    },
+    {
+      "description": "Update annotated commented image versions in YAML files.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*#[\\t ]*dockerImage:[\\t ]+[^\\s:]+(?:/[^\\s:]+)*:(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[^\\S\\r\\n]*"
+      ]
+    },
+    {
+      "description": "Update annotated version directives in configuration files.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).+\\.conf$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*version[\\t ]+(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[^\\S\\r\\n]*"
+      ]
+    },
+    {
+      "description": "Update annotated go install versions in Makefiles.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
+      ]
+    }
+  ]
+}

--- a/base.json
+++ b/base.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Apply the explicit baseline for repository Renovate configuration"],
+  "extends": [
+    "config:best-practices",
+    "schedule:weekly"
+  ],
+  "labels": ["dependencies"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps"
+}

--- a/github-actions.json
+++ b/github-actions.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Group GitHub Actions updates by ownership and update compatibility"],
+  "packageRules": [
+    {
+      "description": ["Group third-party GitHub Actions non-major updates"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!Netcracker/**", "!netcracker/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
+      "groupName": "third-party GitHub Actions"
+    },
+    {
+      "description": ["Group third-party GitHub Actions major updates separately"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!Netcracker/**", "!netcracker/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major third-party GitHub Actions"
+    },
+    {
+      "description": ["Group Netcracker GitHub Actions non-major updates"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
+      "groupName": "Netcracker GitHub Actions"
+    },
+    {
+      "description": ["Group Netcracker GitHub Actions major updates separately"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major Netcracker GitHub Actions"
+    }
+  ]
+}

--- a/go-tidy.json
+++ b/go-tidy.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Run go mod tidy after Go module updates when a repository opts in"],
+  "packageRules": [
+    {
+      "description": ["Run go mod tidy after Go module updates"],
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"]
+    }
+  ]
+}

--- a/go.json
+++ b/go.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Group related Go dependency families without modifying unrelated modules"],
+  "packageRules": [
+    {
+      "description": ["Group Kubernetes Go modules"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
+      "groupName": "Kubernetes Go modules"
+    },
+    {
+      "description": ["Group OpenTelemetry Go modules"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/**", "github.com/open-telemetry/**"],
+      "groupName": "OpenTelemetry Go modules"
+    },
+    {
+      "description": ["Group Prometheus Go modules"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/prometheus/**"],
+      "groupName": "Prometheus Go modules"
+    },
+    {
+      "description": ["Group Go toolchain updates"],
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain"
+    }
+  ]
+}

--- a/grafana-plugins.json
+++ b/grafana-plugins.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Update Grafana plugins listed as plugin ID and version pairs"],
+  "customManagers": [
+    {
+      "description": "Update Grafana plugin versions in plugins.list files.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)plugins\\.list$/"],
+      "matchStrings": [
+        "(?:^|\\r?\\n)(?<depName>[a-z0-9-]+)[\\t ]+(?<currentValue>\\d+\\.\\d+\\.\\d+)[^\\S\\r\\n]*"
+      ],
+      "datasourceTemplate": "custom.grafana-plugins",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": ["Group Grafana plugin updates"],
+      "matchDatasources": ["custom.grafana-plugins"],
+      "groupName": "Grafana plugins"
+    }
+  ],
+  "customDatasources": {
+    "grafana-plugins": {
+      "defaultRegistryUrlTemplate": "https://grafana.com/api/plugins/{{packageName}}/versions",
+      "format": "json",
+      "transformTemplates": ["{\"releases\": items.{\"version\": version, \"releaseTimestamp\": createdAt}}"]
+    }
+  }
+}

--- a/graylog-plugins.json
+++ b/graylog-plugins.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Update Graylog plugin JAR URLs backed by GitHub releases"],
+  "customManagers": [
+    {
+      "description": "Update GitHub release tags and JAR versions in Graylog plugins.list files.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)plugins\\.list$/"],
+      "matchStrings": [
+        "https://github\\.com/(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/releases/download/(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)/(?<depName>[A-Za-z0-9_.-]+)-v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?\\.jar"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depTypeTemplate": "graylog-plugin",
+      "versioningTemplate": "semver",
+      "autoReplaceStringTemplate": "https://github.com/{{{packageName}}}/releases/download/{{{newValue}}}/{{{depName}}}-{{{replace '^v' '' newValue}}}.jar"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": ["Group Graylog plugin updates"],
+      "matchDepTypes": ["graylog-plugin"],
+      "groupName": "Graylog plugins"
+    }
+  ]
+}

--- a/netcracker-dependencies.json
+++ b/netcracker-dependencies.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Group internal Netcracker dependencies by ecosystem without a release-age delay"],
+  "packageRules": [
+    {
+      "description": ["Group Netcracker GitHub Actions non-major updates"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
+      "groupName": "Netcracker GitHub Actions",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Group major Netcracker GitHub Actions updates separately"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major Netcracker GitHub Actions",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Group Netcracker Docker images"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/netcracker/**"],
+      "groupName": "Netcracker Docker images",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Group Netcracker Go modules"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/Netcracker/**"],
+      "groupName": "Netcracker Go modules",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Group Netcracker Maven artifacts"],
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["/^com\\.netcracker[.:]/", "/^org\\.qubership[.:]/"],
+      "groupName": "Netcracker Maven artifacts",
+      "minimumReleaseAge": "0 days"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Ignore dependency-like values used only by preset tests"],
+  "extends": [":ignoreModulesAndTests"]
+}

--- a/tests/fixtures/annotated-versions/Dockerfile
+++ b/tests/fixtures/annotated-versions/Dockerfile
@@ -1,0 +1,4 @@
+# renovate: datasource=docker depName=alpine
+ARG ALPINE_VERSION=3.22.0
+
+ARG UNANNOTATED_VERSION=1.2.3

--- a/tests/fixtures/annotated-versions/Makefile
+++ b/tests/fixtures/annotated-versions/Makefile
@@ -1,0 +1,4 @@
+tools:
+	# renovate: datasource=go depName=golang.org/x/tools/gopls versioning=semver
+	go install golang.org/x/tools/gopls@v0.19.1
+	go install example.com/unannotated/tool@v1.0.0

--- a/tests/fixtures/annotated-versions/config.yaml.tmpl
+++ b/tests/fixtures/annotated-versions/config.yaml.tmpl
@@ -1,0 +1,2 @@
+# renovate: datasource=docker depName=ghcr.io/netcracker/example packageName=ghcr.io/netcracker/example versioning=docker
+imageVersion: 1.2.3

--- a/tests/fixtures/annotated-versions/helm-comment.tpl
+++ b/tests/fixtures/annotated-versions/helm-comment.tpl
@@ -1,0 +1,2 @@
+{{/* renovate: datasource=docker depName=otel/opentelemetry-collector-contrib */}}
+{{ print "otel/opentelemetry-collector-contrib:0.131.0" }}

--- a/tests/fixtures/annotated-versions/logging/fluent.conf
+++ b/tests/fixtures/annotated-versions/logging/fluent.conf
@@ -1,0 +1,2 @@
+# renovate: datasource=github-releases depName=Netcracker/qubership-fluentd versioning=loose
+version 1.19.2-2

--- a/tests/fixtures/annotated-versions/logging/templates/graylog-image.tpl
+++ b/tests/fixtures/annotated-versions/logging/templates/graylog-image.tpl
@@ -1,0 +1,2 @@
+{{- /* # renovate: datasource=docker depName=graylog/graylog */ -}}
+{{- print "docker.io/graylog/graylog:5.2.12" -}}

--- a/tests/fixtures/annotated-versions/logging/values.yaml
+++ b/tests/fixtures/annotated-versions/logging/values.yaml
@@ -1,0 +1,2 @@
+# renovate: datasource=github-releases depName=Netcracker/qubership-fluentd versioning=loose
+# dockerImage: ghcr.io/netcracker/qubership-fluentd:1.19.2-2

--- a/tests/fixtures/annotated-versions/monitoring/templates/grafana-image.tpl
+++ b/tests/fixtures/annotated-versions/monitoring/templates/grafana-image.tpl
@@ -1,0 +1,2 @@
+{{- /* # renovate: datasource=docker depName=quay.io/grafana-operator/grafana-operator */ -}}
+{{- print "quay.io/grafana-operator/grafana-operator:v5.22.2" -}}

--- a/tests/fixtures/annotated-versions/values.yaml
+++ b/tests/fixtures/annotated-versions/values.yaml
@@ -1,0 +1,4 @@
+# renovate: datasource=github-releases depName=prometheus/prometheus
+prometheusVersion: v3.5.0
+
+unannotatedVersion: v1.0.0

--- a/tests/fixtures/grafana-plugins/plugins.list
+++ b/tests/fixtures/grafana-plugins/plugins.list
@@ -1,0 +1,3 @@
+# Data sources
+retrodaredevil-wildgraphql-datasource 1.6.1
+victoriametrics-metrics-datasource 0.25.1

--- a/tests/fixtures/graylog-plugins/plugins.list
+++ b/tests/fixtures/graylog-plugins/plugins.list
@@ -1,0 +1,4 @@
+# Release tag without a v prefix
+https://github.com/graylog-labs/graylog-plugin-metrics-reporter/releases/download/3.0.0/metrics-reporter-prometheus-3.0.0.jar
+# Release tag with a v prefix
+https://github.com/irgendwr/TelegramAlert/releases/download/v2.3.7/graylog-plugin-telegram-notification-2.3.7.jar


### PR DESCRIPTION
## Summary

- add reusable capability presets for baseline policy, GitHub Actions, Go, Netcracker dependencies, annotated versions, and plugin lists
- keep `go-tidy` separate so repositories opt in to broader `go.mod` and `go.sum` changes
- ignore dependency-like values in test fixtures through the repository Renovate config
- add extraction fixtures, policy assertions, and automatic Renovate config validation
- document explicit capability composition

## Impact

The capability presets are additive and have no current consumers. This PR does not change `default.json`, `org-inherited-config.json`, or `apm.json`, and it does not enable automerge. The organization-wide minimum release age remains unchanged; zero-day exceptions are limited to the opt-in Netcracker dependencies preset.

The root `renovate.json` extends the official `:ignoreModulesAndTests` preset so Renovate does not update dependency-like fixture values under `tests/**`.

## Verification

- full `Validate Renovate Config` job passed locally with `act`
- Renovate strict validation passed for 11 shared configs and the repository config
- real extraction with `renovate/renovate:latest` found 9 annotated dependencies, 2 Grafana plugins, and 2 Graylog plugins
- full-repository Renovate extraction found only 25 real GitHub Actions dependencies and no files under `tests/**`
- `actionlint`, organization markdownlint, and `git diff --check` passed