### PR TITLE
feat: add reusable test pipelines preset

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -7,6 +7,7 @@ const presetNames = [
   'go',
   'go-tidy',
   'netcracker-dependencies',
+  'test-pipelines',
   'annotated-versions',
   'grafana-plugins',
   'graylog-plugins',
@@ -42,6 +43,17 @@ function managerMatchesPath(manager, path) {
 
 function extract(manager, content) {
   return compileManager(manager).flatMap((regex) => [...content.matchAll(regex)].map((match) => match.groups));
+}
+
+function replaceRegexDependency(manager, content, dependencyIndex, newValue, newDigest) {
+  const matches = compileManager(manager).flatMap((regex) => [...content.matchAll(regex)]);
+  const match = matches[dependencyIndex];
+  assert.ok(match, `Dependency index ${dependencyIndex} was not found`);
+
+  const replacement = match[0]
+    .replace(match.groups.currentValue, newValue)
+    .replace(match.groups.currentDigest, newDigest);
+  return `${content.slice(0, match.index)}${replacement}${content.slice(match.index + match[0].length)}`;
 }
 
 function render(template, values) {
@@ -230,6 +242,51 @@ function assertAnnotatedVersions(config) {
   }
 }
 
+function assertTestPipelines(config) {
+  const manager = config.customManagers[0];
+  const fixture = readFixture('test-pipelines/workflows.yaml');
+  const dependencies = extract(manager, fixture);
+
+  assert.equal(managerMatchesPath(manager, '.github/workflows/integration-tests.yaml'), true);
+  assert.equal(managerMatchesPath(manager, '.github/workflows/run_tests.yml'), true);
+  assert.equal(managerMatchesPath(manager, 'docs/workflows.yaml'), false);
+  assert.equal(manager.datasourceTemplate, 'github-tags');
+
+  assert.deepEqual(
+    dependencies.map(({ depName, currentValue, currentDigest }) => [depName, currentValue, currentDigest]),
+    [
+      [
+        'Netcracker/qubership-test-pipelines',
+        'v1.14.1',
+        'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8',
+      ],
+      [
+        'Netcracker/qubership-test-pipelines',
+        'v1.8.0',
+        '247c69038e00f2a9e283412e902555f84b16dab2',
+      ],
+      ['Netcracker/qubership-test-pipelines', 'v2', 'abcdef0'],
+    ]
+  );
+
+  const replacement = replaceRegexDependency(
+    manager,
+    fixture,
+    0,
+    'v1.15.0',
+    '0123456789abcdef0123456789abcdef01234567'
+  );
+  const updated = extract(manager, replacement);
+
+  assert.equal(updated.length, dependencies.length);
+  assert.equal(updated[0].currentValue, 'v1.15.0');
+  assert.equal(updated[0].currentDigest, '0123456789abcdef0123456789abcdef01234567');
+  assert.match(
+    replacement,
+    /pipeline_branch: '0123456789abcdef0123456789abcdef01234567' # v1\.15\.0 renovate: depName=Netcracker\/qubership-test-pipelines/
+  );
+}
+
 function assertGrafanaPlugins(config) {
   const manager = config.customManagers[0];
   const dependencies = extract(manager, readFixture('grafana-plugins/plugins.list'));
@@ -275,6 +332,7 @@ assertGitHubActionsPolicy(configs['github-actions']);
 assertGoPolicy(configs.go);
 assertGoTidyPolicy(configs['go-tidy']);
 assertNetcrackerPolicy(configs['netcracker-dependencies']);
+assertTestPipelines(configs['test-pipelines']);
 assertAnnotatedVersions(configs['annotated-versions']);
 assertGrafanaPlugins(configs['grafana-plugins']);
 assertGraylogPlugins(configs['graylog-plugins']);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ a team-specific preset:
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
 - `annotated-versions` updates explicitly annotated Docker, YAML, template, and Makefile values.
+- `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
 - `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.
 - `apm` updates APM package references in `apm.yml`.
@@ -79,6 +80,25 @@ For example, a Go repository that uses annotated tool versions can compose these
 ```
 
 Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository decision.
+
+## `test-pipelines.json` preset
+
+[`test-pipelines.json`](./test-pipelines.json) updates annotated `pipeline_branch` inputs in GitHub Actions workflows.
+It complements Renovate's built-in `github-actions` manager, which updates the reusable workflow reference.
+
+Enable the preset in the repository Renovate configuration:
+
+```json
+{
+  "extends": ["github>Netcracker/renovate-config:test-pipelines"]
+}
+```
+
+Add the release tag and package annotation after each pinned `pipeline_branch` commit:
+
+```yaml
+pipeline_branch: 'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8' # v1.14.1 renovate: depName=Netcracker/qubership-test-pipelines
+```
 
 ## `apm.json` preset
 

--- a/test-pipelines.json
+++ b/test-pipelines.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Keep reusable test pipeline workflow references and pipeline_branch inputs aligned"],
+  "customManagers": [
+    {
+      "description": "Update annotated qubership-test-pipelines commit references.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "pipeline_branch:\\s+[\"'](?<currentDigest>[a-f0-9]+)[\"']\\s+#\\s*(?<currentValue>v\\S+)\\s+renovate:\\s+depName=(?<depName>\\S+)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ]
+}

--- a/tests/fixtures/test-pipelines/workflows.yaml
+++ b/tests/fixtures/test-pipelines/workflows.yaml
@@ -1,0 +1,12 @@
+jobs:
+  Monitoring-Pipeline:
+    with:
+      pipeline_branch: 'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8' # v1.14.1 renovate: depName=Netcracker/qubership-test-pipelines
+
+  Consul-Pipeline:
+    with:
+      pipeline_branch: "247c69038e00f2a9e283412e902555f84b16dab2" # v1.8.0 renovate: depName=Netcracker/qubership-test-pipelines
+
+  Compatible-Pipeline:
+    with:
+      pipeline_branch: 'abcdef0' # v2 renovate: depName=Netcracker/qubership-test-pipelines


### PR DESCRIPTION
## Why

Repositories that consume `Netcracker/qubership-test-pipelines` must keep the reusable workflow SHA and the separate `pipeline_branch` input aligned. Without a custom manager, Renovate updates the `uses` reference but leaves `pipeline_branch` stale.

The same custom manager pattern is already used in:

- [Netcracker/qubership-opensearch](https://github.com/Netcracker/qubership-opensearch/blob/main/renovate.json)
- [Netcracker/qubership-kafka](https://github.com/Netcracker/qubership-kafka/blob/main/renovate.json)
- [Netcracker/qubership-consul](https://github.com/Netcracker/qubership-consul/blob/main/renovate.json)
- [Netcracker/qubership-rabbitmq](https://github.com/Netcracker/qubership-rabbitmq/blob/main/renovate.json)
- [Netcracker/qubership-zookeeper](https://github.com/Netcracker/qubership-zookeeper/blob/main/renovate.json)

[Netcracker/qubership-consul#208](https://github.com/Netcracker/qubership-consul/pull/208/files) demonstrates Renovate updating both values together.

## What

- Add the opt-in `test-pipelines` capability preset.
- Match annotated `pipeline_branch` values in GitHub Actions workflow YAML files.
- Extract the Git tag as `currentValue` and its commit SHA as `currentDigest` through the `github-tags` datasource.
- Add extraction and replacement regression coverage for quote styles, full and abbreviated digests, and major-only tags.
- Document `github>Netcracker/renovate-config:test-pipelines` and its annotation format.

The preset is opt-in and does not change the organization-wide inherited configuration.

## How to verify

- `node .github/scripts/test-presets.mjs`
- `node .github/scripts/validate-apm-regex.mjs`
- `renovate-config-validator --strict --no-global` for all shared configs and `renovate.json`
