### PR TITLE
fix: skip release-age delay for in-house GitHub Actions and workflows

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -39,6 +39,12 @@
       "minimumReleaseAge": "0 days"
     },
     {
+      "description": ["Skip the release-age delay for in-house GitHub Actions/workflows"],
+      "matchDatasources": ["github-tags", "github-digest"],
+      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": ["Skip the release-age delay for Go toolchain updates (go and toolchain directives)"],
       "matchDatasources": ["golang-version"],
       "minimumReleaseAge": "0 days"


### PR DESCRIPTION
## What

Exempt in-house Netcracker GitHub Actions and reusable workflows from the global 7-day `minimumReleaseAge` delay, so their updates are proposed immediately.

## Why

We consume our own actions and reusable workflows across all repos, e.g. `Netcracker/qubership-workflow-hub/` and `Netcracker/qubership-core-infra/`. For internal code we want new versions right away - the stabilization window only makes sense for third-party deps.

## How
New `packageRule`
```json
{
      "description": ["Skip the release-age delay for in-house GitHub Actions/workflows"],
      "matchDatasources": ["github-tags", "github-digest"],
      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
      "minimumReleaseAge": "0 days"
}
```
Scoped to the `github-tags/github-digest` datasources used by GitHub Actions references. Matching by owner prefix covers every internal action/workflow regardless of subpath (`/actions/...`, `/.github/workflows/...`); both casings are listed since the owner appears as both `Netcracker/` and `netcracker/` across workflow files.