### PR TITLE
feat: sync Alpine Repology repositories with base image

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -242,6 +242,64 @@ function assertAnnotatedVersions(config) {
   }
 }
 
+function assertAlpineRepologySync(config) {
+  const managerDescription = 'Keep Alpine Repology repositories in sync with the Alpine image.';
+  const manager = config.customManagers.find((candidate) => candidate.description === managerDescription);
+  assert.ok(manager, `Custom manager not found: ${managerDescription}`);
+
+  const fixture = readFixture('annotated-versions/Dockerfile.alpine-sync');
+  const dependencies = extract(manager, fixture);
+  const argManager = config.customManagers.find(
+    (candidate) => candidate.description === 'Update annotated Docker ARG version values.'
+  );
+  const packageDependencies = extract(argManager, fixture);
+
+  assert.equal(managerMatchesPath(manager, 'Dockerfile'), true);
+  assert.equal(managerMatchesPath(manager, 'containers/Containerfile.runtime'), true);
+  assert.equal(managerMatchesPath(manager, 'containers/image.yaml'), false);
+  assert.equal(manager.datasourceTemplate, 'docker');
+  assert.equal(manager.depNameTemplate, 'alpine');
+  assert.equal(manager.packageNameTemplate, 'alpine');
+  assert.equal(manager.versioningTemplate, 'docker');
+  assert.equal(manager.currentValueTemplate, "{{{ replace '_' '.' currentValue }}}");
+  assert.equal(dependencies.length, 1, 'Only annotations marked with syncWith=alpine must be synchronized');
+  assert.deepEqual(
+    packageDependencies.map(({ depName, currentValue }) => [depName, currentValue]),
+    [
+      ['alpine_3_22/build-base', '0.5-r3'],
+      ['alpine_3_23/busybox', '1.37.0-r31'],
+    ],
+    'The sync marker must not hide the APK package dependency'
+  );
+  assert.deepEqual(
+    {
+      currentValue: dependencies[0].currentValue,
+      packageName: dependencies[0].alpinePackage,
+      packageVersioning: dependencies[0].packageVersioning,
+    },
+    {
+      currentValue: '3_23',
+      packageName: 'busybox',
+      packageVersioning: 'apk',
+    }
+  );
+
+  const replacement = render(manager.autoReplaceStringTemplate, {
+    ...dependencies[0],
+    newMajor: '3',
+    newMinor: '25',
+  });
+  assert.equal(
+    replacement,
+    '# renovate: datasource=repology depName=alpine_3_25/busybox versioning=apk syncWith=alpine'
+  );
+
+  const rule = findRule(config, 'Group Alpine image and synchronized Repology repository updates');
+  assert.deepEqual(rule.matchDatasources, ['docker']);
+  assert.deepEqual(rule.matchPackageNames, ['alpine']);
+  assert.equal(rule.groupName, 'alpine-release');
+}
+
 function assertTestPipelines(config) {
   const manager = config.customManagers[0];
   const fixture = readFixture('test-pipelines/workflows.yaml');
@@ -334,6 +392,7 @@ assertGoTidyPolicy(configs['go-tidy']);
 assertNetcrackerPolicy(configs['netcracker-dependencies']);
 assertTestPipelines(configs['test-pipelines']);
 assertAnnotatedVersions(configs['annotated-versions']);
+assertAlpineRepologySync(configs['annotated-versions']);
 assertGrafanaPlugins(configs['grafana-plugins']);
 assertGraylogPlugins(configs['graylog-plugins']);
 assertNoAutomerge(configs);

--- a/README.md
+++ b/README.md
@@ -81,9 +81,19 @@ For example, a Go repository that uses annotated tool versions can compose these
 
 Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository decision.
 
-## Synchronizing Alpine Repology repositories
+## Update Alpine package annotations with the base image
 
-The `annotated-versions` preset can update an Alpine base image and its release-specific Repology repository identifiers in one `alpine-release` PR. Add `syncWith=alpine` to each APK package annotation that follows an official `alpine` base image:
+Use this feature when a Dockerfile uses an official Alpine image and pins APK package versions through Repology.
+
+Enable the `annotated-versions` preset:
+
+```json
+{
+  "extends": ["github>Netcracker/renovate-config:annotated-versions"]
+}
+```
+
+Add `syncWith=alpine` to each package annotation associated with the Alpine image:
 
 ```dockerfile
 FROM alpine:3.24.1
@@ -92,11 +102,35 @@ FROM alpine:3.24.1
 ARG BUSYBOX_VERSION=1.37.0-r31
 ```
 
-When Renovate updates the image to Alpine 3.25, it also changes `alpine_3_24/busybox` to `alpine_3_25/busybox`. The package version remains unchanged so that the repository's Docker build can verify whether the exact pin is available in the new Alpine release.
+When Renovate updates Alpine 3.24 to 3.25, the same PR also makes this change:
 
-Use the marker only for packages installed in the official `alpine` image that Renovate updates in the same PR. Do not use it for packages installed in derived images such as `golang:1.26-alpine3.24`; those packages must follow the Alpine release embedded in the derived image tag.
+```dockerfile
+FROM alpine:3.25.0
 
-Repository-local package rules can override the preset's `alpine-release` group. If a repository has a catch-all Docker grouping rule, add a later rule that assigns Docker datasource package `alpine` to `alpine-release`.
+# renovate: datasource=repology depName=alpine_3_25/busybox versioning=apk syncWith=alpine
+ARG BUSYBOX_VERSION=1.37.0-r31
+```
+
+The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package
+version. The Docker build verifies that the package version exists in the new Alpine release.
+
+Do not add `syncWith=alpine` to packages installed in derived images such as `golang:1.26-alpine3.24`. Their Alpine
+release is part of the derived image tag and may differ from the official Alpine image.
+
+A repository rule that groups all Docker updates can override the `alpine-release` group. Place this rule after any
+broader Docker grouping rules:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "groupName": "alpine-release"
+    }
+  ]
+}
+```
 
 ## `test-pipelines.json` preset
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ For example, a Go repository that uses annotated tool versions can compose these
 
 Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository decision.
 
+## Synchronizing Alpine Repology repositories
+
+The `annotated-versions` preset can update an Alpine base image and its release-specific Repology repository identifiers in one `alpine-release` PR. Add `syncWith=alpine` to each APK package annotation that follows an official `alpine` base image:
+
+```dockerfile
+FROM alpine:3.24.1
+
+# renovate: datasource=repology depName=alpine_3_24/busybox versioning=apk syncWith=alpine
+ARG BUSYBOX_VERSION=1.37.0-r31
+```
+
+When Renovate updates the image to Alpine 3.25, it also changes `alpine_3_24/busybox` to `alpine_3_25/busybox`. The package version remains unchanged so that the repository's Docker build can verify whether the exact pin is available in the new Alpine release.
+
+Use the marker only for packages installed in the official `alpine` image that Renovate updates in the same PR. Do not use it for packages installed in derived images such as `golang:1.26-alpine3.24`; those packages must follow the Alpine release embedded in the derived image tag.
+
+Repository-local package rules can override the preset's `alpine-release` group. If a repository has a catch-all Docker grouping rule, add a later rule that assigns Docker datasource package `alpine` to `alpine-release`.
+
 ## `test-pipelines.json` preset
 
 [`test-pipelines.json`](./test-pipelines.json) updates annotated `pipeline_branch` inputs in GitHub Actions workflows.

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -7,8 +7,22 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)(?:Dockerfile|Containerfile)(?:\\.[^/]+)?$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*ARG [A-Za-z_][A-Za-z0-9_]*[ =][\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?(?: syncWith=alpine)?[^\\S\\r\\n]*\\r?\\n[\\t ]*ARG [A-Za-z_][A-Za-z0-9_]*[ =][\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
       ]
+    },
+    {
+      "description": "Keep Alpine Repology repositories in sync with the Alpine image.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)(?:Dockerfile|Containerfile)(?:\\.[^/]+)?$/"],
+      "matchStrings": [
+        "# renovate: datasource=repology depName=alpine_(?<currentValue>\\d+_\\d+)/(?<alpinePackage>[^\\s]+) versioning=(?<packageVersioning>[^\\s]+) syncWith=alpine"
+      ],
+      "currentValueTemplate": "{{{ replace '_' '.' currentValue }}}",
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "alpine",
+      "packageNameTemplate": "alpine",
+      "versioningTemplate": "docker",
+      "autoReplaceStringTemplate": "# renovate: datasource=repology depName=alpine_{{{newMajor}}}_{{{newMinor}}}/{{{alpinePackage}}} versioning={{{packageVersioning}}} syncWith=alpine"
     },
     {
       "description": "Update annotated next-line YAML and template version values.",
@@ -49,6 +63,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
       ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": ["Group Alpine image and synchronized Repology repository updates"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "groupName": "alpine-release"
     }
   ]
 }

--- a/tests/fixtures/annotated-versions/Dockerfile.alpine-sync
+++ b/tests/fixtures/annotated-versions/Dockerfile.alpine-sync
@@ -1,0 +1,9 @@
+FROM golang:1.26.5-alpine3.22 AS builder
+
+# renovate: datasource=repology depName=alpine_3_22/build-base versioning=apk
+ARG BUILD_BASE_VERSION=0.5-r3
+
+FROM alpine:3.23.4
+
+# renovate: datasource=repology depName=alpine_3_23/busybox versioning=apk syncWith=alpine
+ARG BUSYBOX_VERSION=1.37.0-r31


### PR DESCRIPTION
## Why

Updating `FROM alpine:3.24.1` to `FROM alpine:3.25` does not update Repology annotations such as `depName=alpine_3_24/busybox`. The image and package repository can then target different Alpine releases.

## What

- Add the opt-in `syncWith=alpine` marker for Repology annotations.
- Update `alpine_3_24/*` to `alpine_3_25/*` in the same Renovate PR as the Alpine image.
- Keep the pinned APK package version unchanged so the Docker build validates its availability.
- Leave unmarked annotations unchanged, which allows multi-stage Dockerfiles to use packages from another Alpine release.
- Group both updates under `alpine-release`.

No breaking changes. Existing annotations remain unchanged unless they use `syncWith=alpine`.

Repository-local `packageRules` that match Alpine may override the `alpine-release` group.

## How to verify

- Run `node .github/scripts/test-presets.mjs`.
- Run `node .github/scripts/validate-apm-regex.mjs`.
- Validate the JSON files with Renovate.
- Confirm that the fixture updates `alpine:3.23.4` and `alpine_3_23/busybox` together while leaving `alpine_3_22/build-base` unchanged.
