### PR TITLE
fix(renovate): improve shared preset coverage

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -267,6 +267,7 @@ function assertAlpineRepologySync(config) {
   assert.equal(manager.depNameTemplate, 'alpine');
   assert.equal(manager.packageNameTemplate, 'alpine');
   assert.equal(manager.versioningTemplate, 'docker');
+  assert.equal(manager.depTypeTemplate, 'alpine-release-sync');
   assert.equal(manager.currentValueTemplate, "{{{ replace '_' '.' currentValue }}}");
   assert.equal(dependencies.length, 1, 'Only annotations marked with syncWith=alpine must be synchronized');
   assert.deepEqual(
@@ -304,6 +305,10 @@ function assertAlpineRepologySync(config) {
   assert.deepEqual(rule.matchDatasources, ['docker']);
   assert.deepEqual(rule.matchPackageNames, ['alpine']);
   assert.equal(rule.groupName, 'alpine-release');
+
+  const digestPinning = findRule(config, 'Disable digest pinning for Alpine repository synchronization');
+  assert.deepEqual(digestPinning.matchDepTypes, ['alpine-release-sync']);
+  assert.equal(digestPinning.pinDigests, false);
 
   const repologyReleaseAge = findRule(config, 'Bypass release age for Alpine Repology packages');
   assert.deepEqual(repologyReleaseAge.matchDatasources, ['repology']);

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -99,6 +99,12 @@ function assertGoPolicy(config) {
     findRule(config, description);
   }
   assert.equal(config.packageRules.length, 4, 'go.json must not group unrelated Go dependencies');
+  const kubernetes = findRule(config, 'Group Kubernetes Go modules');
+  assert.deepEqual(kubernetes.matchPackageNames, [
+    'k8s.io/**',
+    'sigs.k8s.io/**',
+    'github.com/openshift/**',
+  ]);
   const openTelemetry = findRule(config, 'Group OpenTelemetry Go modules');
   assert.deepEqual(openTelemetry.matchPackageNames, [
     'go.opentelemetry.io/**',
@@ -298,6 +304,11 @@ function assertAlpineRepologySync(config) {
   assert.deepEqual(rule.matchDatasources, ['docker']);
   assert.deepEqual(rule.matchPackageNames, ['alpine']);
   assert.equal(rule.groupName, 'alpine-release');
+
+  const repologyReleaseAge = findRule(config, 'Bypass release age for Alpine Repology packages');
+  assert.deepEqual(repologyReleaseAge.matchDatasources, ['repology']);
+  assert.deepEqual(repologyReleaseAge.matchPackageNames, ['/^alpine_\\d+_\\d+\\/.+$/']);
+  assert.equal(repologyReleaseAge.minimumReleaseAge, '0 days');
 }
 
 function assertTestPipelines(config) {
@@ -357,6 +368,9 @@ function assertGrafanaPlugins(config) {
   );
   assert.ok(config.customDatasources?.['grafana-plugins']);
   assert.equal(manager.datasourceTemplate, 'custom.grafana-plugins');
+  assert.deepEqual(config.customDatasources['grafana-plugins'].transformTemplates, [
+    '{"releases": [items.{"version": version, "releaseTimestamp": createdAt}]}',
+  ]);
 }
 
 function assertGraylogPlugins(config) {

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ FROM alpine:3.25.0
 ARG BUSYBOX_VERSION=1.37.0-r31
 ```
 
-The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package version. Repology does not provide release timestamps, so Alpine Repology updates bypass the organization release-age delay. Renovate does not try to add an image digest to the synchronization annotation because the annotation has no digest field. The Docker build verifies that the package version exists in the new Alpine release.
+The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package version. Repology does not provide release timestamps, so Alpine Repology updates bypass the organization release-age delay.
+
+Renovate does not try to add an image digest to the synchronization annotation because the annotation has no digest field. The Docker build verifies that the package version exists in the new Alpine release.
 
 Do not add `syncWith=alpine` to packages installed in derived images such as `golang:1.26-alpine3.24`. Their Alpine
 release is part of the derived image tag and may differ from the official Alpine image.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ a team-specific preset:
 
 - `base` applies an explicit best-practices baseline, weekly schedule, dependency label, and semantic commit settings.
 - `github-actions` groups third-party and Netcracker actions separately, with major updates in separate groups.
-- `go` groups Kubernetes, OpenTelemetry, Prometheus, and Go toolchain updates. It does not group unrelated modules.
+- `go` groups Kubernetes and OpenShift, OpenTelemetry, Prometheus, and Go toolchain updates. It does not group unrelated modules.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
 - `annotated-versions` updates explicitly annotated Docker, YAML, template, and Makefile values.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
-- `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`.
+- `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`, including plugins whose Grafana API response contains only one release.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.
 - `apm` updates APM package references in `apm.yml`.
 
@@ -111,8 +111,7 @@ FROM alpine:3.25.0
 ARG BUSYBOX_VERSION=1.37.0-r31
 ```
 
-The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package
-version. The Docker build verifies that the package version exists in the new Alpine release.
+The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package version. Repology does not provide release timestamps, so Alpine Repology updates bypass the organization release-age delay. The Docker build verifies that the package version exists in the new Alpine release.
 
 Do not add `syncWith=alpine` to packages installed in derived images such as `golang:1.26-alpine3.24`. Their Alpine
 release is part of the derived image tag and may differ from the official Alpine image.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ FROM alpine:3.25.0
 ARG BUSYBOX_VERSION=1.37.0-r31
 ```
 
-The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package version. Repology does not provide release timestamps, so Alpine Repology updates bypass the organization release-age delay. The Docker build verifies that the package version exists in the new Alpine release.
+The synchronization changes the Alpine image and the Repology repository. It does not change the pinned package version. Repology does not provide release timestamps, so Alpine Repology updates bypass the organization release-age delay. Renovate does not try to add an image digest to the synchronization annotation because the annotation has no digest field. The Docker build verifies that the package version exists in the new Alpine release.
 
 Do not add `syncWith=alpine` to packages installed in derived images such as `golang:1.26-alpine3.24`. Their Alpine
 release is part of the derived image tag and may differ from the official Alpine image.

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -22,6 +22,7 @@
       "depNameTemplate": "alpine",
       "packageNameTemplate": "alpine",
       "versioningTemplate": "docker",
+      "depTypeTemplate": "alpine-release-sync",
       "autoReplaceStringTemplate": "# renovate: datasource=repology depName=alpine_{{{newMajor}}}_{{{newMinor}}}/{{{alpinePackage}}} versioning={{{packageVersioning}}} syncWith=alpine"
     },
     {
@@ -71,6 +72,11 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["alpine"],
       "groupName": "alpine-release"
+    },
+    {
+      "description": ["Disable digest pinning for Alpine repository synchronization"],
+      "matchDepTypes": ["alpine-release-sync"],
+      "pinDigests": false
     },
     {
       "description": ["Bypass release age for Alpine Repology packages"],

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -71,6 +71,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["alpine"],
       "groupName": "alpine-release"
+    },
+    {
+      "description": ["Bypass release age for Alpine Repology packages"],
+      "matchDatasources": ["repology"],
+      "matchPackageNames": ["/^alpine_\\d+_\\d+\\/.+$/"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }

--- a/go.json
+++ b/go.json
@@ -5,7 +5,7 @@
     {
       "description": ["Group Kubernetes Go modules"],
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**", "github.com/openshift/**"],
       "groupName": "Kubernetes Go modules"
     },
     {

--- a/grafana-plugins.json
+++ b/grafana-plugins.json
@@ -24,7 +24,7 @@
     "grafana-plugins": {
       "defaultRegistryUrlTemplate": "https://grafana.com/api/plugins/{{packageName}}/versions",
       "format": "json",
-      "transformTemplates": ["{\"releases\": items.{\"version\": version, \"releaseTimestamp\": createdAt}}"]
+      "transformTemplates": ["{\"releases\": [items.{\"version\": version, \"releaseTimestamp\": createdAt}]}"]
     }
   }
 }


### PR DESCRIPTION
## What

- Let existing Alpine Repology dependencies bypass the release-age delay because Repology does not provide release timestamps.
- Prevent synthetic Alpine repository synchronization dependencies from proposing digest pins that their annotations cannot store.
- Group OpenShift Go modules with Kubernetes modules.
- Keep Grafana plugin releases as an array when the Grafana API returns only one release.

## Why

These changes prevent valid Alpine package updates from remaining pending, fix the Alpine branch update failure tracked in [qubership-grafana-operator-converter#40](https://github.com/Netcracker/qubership-grafana-operator-converter/issues/40), keep related Kubernetes and OpenShift updates together, and fix failed lookups for Grafana plugins with a single published version.

## Verification

- All nine capability preset tests pass.
- All 13 JSON configs pass strict repository-config validation.
- An A/B run with Mend Renovate 43.280.0 confirms that synthetic Alpine synchronization dependencies no longer receive `pinDigest` updates, while the native Alpine image keeps digest updates and Repology package dependencies remain separate.
- JSONata checks preserve arrays for one and multiple Grafana plugin releases.