### PR TITLE
feat(go): group toolchain versions across managers

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -334,6 +334,14 @@ function assertAnnotatedVersions(config) {
     assert.equal(matches[0].dependency.packageName, packageName);
     assert.equal(matches[0].dependency.versioning, versioning);
   }
+
+  const overlappingPath = 'annotated-versions/.env.mk';
+  const overlappingContent =
+    '# renovate: datasource=github-releases depName=Netcracker/example versioning=semver\nVERSION=1.2.3\n';
+  const overlappingMatches = config.customManagers
+    .filter((manager) => managerMatchesPath(manager, overlappingPath))
+    .flatMap((manager) => extract(manager, overlappingContent));
+  assert.equal(overlappingMatches.length, 1, `${overlappingPath} must be handled by only one custom manager`);
 }
 
 function assertAlpineRepologySync(config) {

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -44,14 +44,13 @@ function compileManager(manager) {
 }
 
 function managerMatchesPath(manager, path) {
-  const matches = (pattern) => {
-    const regexPattern = pattern.startsWith('!') ? pattern.slice(1) : pattern;
+  return manager.managerFilePatterns.some((pattern) => {
+    const negative = pattern.startsWith('!');
+    const regexPattern = negative ? pattern.slice(1) : pattern;
     assert.match(regexPattern, /^\/.+\/$/, `Test runner does not support non-regex file pattern: ${pattern}`);
-    return new RegExp(regexPattern.slice(1, -1)).test(path);
-  };
-  const positivePatterns = manager.managerFilePatterns.filter((pattern) => !pattern.startsWith('!'));
-  const negativePatterns = manager.managerFilePatterns.filter((pattern) => pattern.startsWith('!'));
-  return positivePatterns.some(matches) && !negativePatterns.some(matches);
+    const matched = new RegExp(regexPattern.slice(1, -1)).test(path);
+    return negative ? !matched : matched;
+  });
 }
 
 function extract(manager, content) {
@@ -271,7 +270,7 @@ function assertAnnotatedVersions(config) {
     ],
     [
       'annotated-versions/variables.mk',
-      'Update annotated version variables in Makefiles.',
+      'Update annotated version variables in Makefiles and environment files.',
       'sigs.k8s.io/controller-tools',
       'v0.20.0',
       undefined,
@@ -279,7 +278,7 @@ function assertAnnotatedVersions(config) {
     ],
     [
       'annotated-versions/kind.env',
-      'Update annotated version variables in environment files.',
+      'Update annotated version variables in Makefiles and environment files.',
       'Netcracker/qubership-opensearch',
       '2.3.0',
       undefined,

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -243,6 +243,14 @@ function assertAnnotatedVersions(config) {
       'semver',
     ],
     [
+      'annotated-versions/variables.mk',
+      'Update annotated version variables in Makefiles.',
+      'sigs.k8s.io/controller-tools',
+      'v0.20.0',
+      undefined,
+      'semver',
+    ],
+    [
       'annotated-versions/monitoring/templates/grafana-image.tpl',
       'Update annotated image versions in Helm print templates.',
       'quay.io/grafana-operator/grafana-operator',

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -44,10 +44,14 @@ function compileManager(manager) {
 }
 
 function managerMatchesPath(manager, path) {
-  return manager.managerFilePatterns.some((pattern) => {
-    assert.match(pattern, /^\/.+\/$/, `Test runner does not support non-regex file pattern: ${pattern}`);
-    return new RegExp(pattern.slice(1, -1)).test(path);
-  });
+  const matches = (pattern) => {
+    const regexPattern = pattern.startsWith('!') ? pattern.slice(1) : pattern;
+    assert.match(regexPattern, /^\/.+\/$/, `Test runner does not support non-regex file pattern: ${pattern}`);
+    return new RegExp(regexPattern.slice(1, -1)).test(path);
+  };
+  const positivePatterns = manager.managerFilePatterns.filter((pattern) => !pattern.startsWith('!'));
+  const negativePatterns = manager.managerFilePatterns.filter((pattern) => pattern.startsWith('!'));
+  return positivePatterns.some(matches) && !negativePatterns.some(matches);
 }
 
 function extract(manager, content) {
@@ -342,6 +346,15 @@ function assertAnnotatedVersions(config) {
     .filter((manager) => managerMatchesPath(manager, overlappingPath))
     .flatMap((manager) => extract(manager, overlappingContent));
   assert.equal(overlappingMatches.length, 1, `${overlappingPath} must be handled by only one custom manager`);
+
+  const hiddenMakePath = 'annotated-versions/.tools.mk';
+  const hiddenMakeContent =
+    '# renovate: datasource=go depName=sigs.k8s.io/controller-tools versioning=semver\n' +
+    'go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.1\n';
+  const hiddenMakeMatches = config.customManagers
+    .filter((manager) => managerMatchesPath(manager, hiddenMakePath))
+    .flatMap((manager) => extract(manager, hiddenMakeContent));
+  assert.equal(hiddenMakeMatches.length, 1, `${hiddenMakePath} must preserve hidden Makefile support`);
 }
 
 function assertAlpineRepologySync(config) {

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -30,6 +30,14 @@ function findRule(config, description) {
   return rule;
 }
 
+function ruleMatchesDependency(rule, dependency) {
+  return [
+    ['matchManagers', dependency.manager],
+    ['matchDatasources', dependency.datasource],
+    ['matchPackageNames', dependency.depName],
+  ].every(([matcher, value]) => !rule[matcher] || rule[matcher].includes(value));
+}
+
 function compileManager(manager) {
   return manager.matchStrings.map((matchString) => new RegExp(matchString, 'g'));
 }
@@ -94,11 +102,12 @@ function assertGoPolicy(config) {
     'Group Kubernetes Go modules',
     'Group OpenTelemetry Go modules',
     'Group Prometheus Go modules',
-    'Group Go toolchain updates',
+    'Group Go toolchain versions',
+    'Group official Go builder images with Go toolchain updates',
   ]) {
     findRule(config, description);
   }
-  assert.equal(config.packageRules.length, 4, 'go.json must not group unrelated Go dependencies');
+  assert.equal(config.packageRules.length, 5, 'go.json must not group unrelated Go dependencies');
   const kubernetes = findRule(config, 'Group Kubernetes Go modules');
   assert.deepEqual(kubernetes.matchPackageNames, [
     'k8s.io/**',
@@ -110,6 +119,46 @@ function assertGoPolicy(config) {
     'go.opentelemetry.io/**',
     'github.com/open-telemetry/**',
   ]);
+
+  const toolchain = findRule(config, 'Group Go toolchain versions');
+  assert.equal(
+    ruleMatchesDependency(toolchain, {
+      manager: 'github-actions',
+      datasource: 'golang-version',
+      depName: 'go',
+    }),
+    true,
+    'Explicit GitHub Actions Go versions must join the Go toolchain group'
+  );
+  assert.equal(
+    ruleMatchesDependency(toolchain, {
+      manager: 'github-actions',
+      datasource: 'github-tags',
+      depName: 'actions/setup-go',
+    }),
+    false,
+    'The setup-go action version must stay in the GitHub Actions group'
+  );
+
+  const builderImage = findRule(config, 'Group official Go builder images with Go toolchain updates');
+  assert.equal(
+    ruleMatchesDependency(builderImage, {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      depName: 'golang',
+    }),
+    true,
+    'The official golang image must join the Go toolchain group'
+  );
+  assert.equal(
+    ruleMatchesDependency(builderImage, {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      depName: 'alpine',
+    }),
+    false,
+    'Unrelated Docker images must stay outside the Go toolchain group'
+  );
 }
 
 function assertGoTidyPolicy(config) {

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -274,6 +274,14 @@ function assertAnnotatedVersions(config) {
       'semver',
     ],
     [
+      'annotated-versions/kind.env',
+      'Update annotated version variables in environment files.',
+      'Netcracker/qubership-opensearch',
+      '2.3.0',
+      undefined,
+      'semver',
+    ],
+    [
       'annotated-versions/monitoring/templates/grafana-image.tpl',
       'Update annotated image versions in Helm print templates.',
       'quay.io/grafana-operator/grafana-operator',

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -34,7 +34,8 @@ function ruleMatchesDependency(rule, dependency) {
   return [
     ['matchManagers', dependency.manager],
     ['matchDatasources', dependency.datasource],
-    ['matchPackageNames', dependency.depName],
+    ['matchPackageNames', dependency.packageName ?? dependency.depName],
+    ['matchDepNames', dependency.depName],
   ].every(([matcher, value]) => !rule[matcher] || rule[matcher].includes(value));
 }
 
@@ -86,7 +87,17 @@ function assertGitHubActionsPolicy(config) {
   const majorNetcracker = findRule(config, 'Group Netcracker GitHub Actions major updates separately');
   const nonMajorUpdateTypes = ['minor', 'patch', 'pin', 'digest', 'pinDigest'];
   assert.deepEqual(thirdParty.matchManagers, ['github-actions']);
+  const thirdPartyDepNames = [
+    '!go',
+    '!golang',
+    '!docker.io/library/golang',
+    '!index.docker.io/library/golang',
+    '!registry-1.docker.io/library/golang',
+  ];
   assert.deepEqual(thirdParty.matchPackageNames, ['!Netcracker/**', '!netcracker/**']);
+  assert.deepEqual(majorThirdParty.matchPackageNames, ['!Netcracker/**', '!netcracker/**']);
+  assert.deepEqual(thirdParty.matchDepNames, thirdPartyDepNames);
+  assert.deepEqual(majorThirdParty.matchDepNames, thirdPartyDepNames);
   assert.deepEqual(netcracker.matchPackageNames, ['Netcracker/**', 'netcracker/**']);
   for (const rule of [thirdParty, netcracker]) {
     assert.deepEqual(rule.matchUpdateTypes, nonMajorUpdateTypes);
@@ -103,11 +114,12 @@ function assertGoPolicy(config) {
     'Group OpenTelemetry Go modules',
     'Group Prometheus Go modules',
     'Group Go toolchain versions',
+    'Group explicit GitHub Actions Go versions with Go toolchain updates',
     'Group official Go builder images with Go toolchain updates',
   ]) {
     findRule(config, description);
   }
-  assert.equal(config.packageRules.length, 5, 'go.json must not group unrelated Go dependencies');
+  assert.equal(config.packageRules.length, 6, 'go.json must not group unrelated Go dependencies');
   const kubernetes = findRule(config, 'Group Kubernetes Go modules');
   assert.deepEqual(kubernetes.matchPackageNames, [
     'k8s.io/**',
@@ -123,33 +135,44 @@ function assertGoPolicy(config) {
   const toolchain = findRule(config, 'Group Go toolchain versions');
   assert.equal(
     ruleMatchesDependency(toolchain, {
-      manager: 'github-actions',
+      manager: 'gomod',
       datasource: 'golang-version',
       depName: 'go',
     }),
     true,
-    'Explicit GitHub Actions Go versions must join the Go toolchain group'
+    'go.mod Go versions must join the Go toolchain group'
   );
+
+  const setupGoVersion = findRule(config, 'Group explicit GitHub Actions Go versions with Go toolchain updates');
   assert.equal(
-    ruleMatchesDependency(toolchain, {
+    ruleMatchesDependency(setupGoVersion, {
       manager: 'github-actions',
-      datasource: 'github-tags',
-      depName: 'actions/setup-go',
+      datasource: 'github-releases',
+      depName: 'go',
+      packageName: 'actions/go-versions',
     }),
-    false,
-    'The setup-go action version must stay in the GitHub Actions group'
+    true,
+    'Explicit actions/setup-go Go versions must join the Go toolchain group'
   );
 
   const builderImage = findRule(config, 'Group official Go builder images with Go toolchain updates');
-  assert.equal(
-    ruleMatchesDependency(builderImage, {
-      manager: 'dockerfile',
-      datasource: 'docker',
-      depName: 'golang',
-    }),
-    true,
-    'The official golang image must join the Go toolchain group'
-  );
+  for (const depName of [
+    'golang',
+    'docker.io/library/golang',
+    'index.docker.io/library/golang',
+    'registry-1.docker.io/library/golang',
+  ]) {
+    assert.equal(
+      ruleMatchesDependency(builderImage, {
+        manager: 'dockerfile',
+        datasource: 'docker',
+        depName,
+        packageName: depName,
+      }),
+      true,
+      `The official ${depName} image must join the Go toolchain group`
+    );
+  }
   assert.equal(
     ruleMatchesDependency(builderImage, {
       manager: 'dockerfile',

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a team-specific preset:
   group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
-- `annotated-versions` updates explicitly annotated Docker, YAML, template, and Makefile values.
+- `annotated-versions` updates annotated Docker, YAML, and template values, Makefile variables, and `go install` commands.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
 - `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`, including plugins whose Grafana API response contains only one release.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a team-specific preset:
   group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
-- `annotated-versions` updates annotated Docker, YAML, and template values, Makefile variables, and `go install` commands.
+- `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
 - `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`, including plugins whose Grafana API response contains only one release.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ a team-specific preset:
 
 - `base` applies an explicit best-practices baseline, weekly schedule, dependency label, and semantic commit settings.
 - `github-actions` groups third-party and Netcracker actions separately, with major updates in separate groups.
-- `go` groups Kubernetes and OpenShift, OpenTelemetry, Prometheus, and Go toolchain updates. It does not group unrelated modules.
+- `go` groups Kubernetes and OpenShift, OpenTelemetry, Prometheus, and Go toolchain updates. Toolchain updates include
+  `go.mod` directives, explicit GitHub Actions Go versions, and official `golang` builder images. The preset does not
+  group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
 - `annotated-versions` updates explicitly annotated Docker, YAML, template, and Makefile values.

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -60,7 +60,10 @@
     {
       "description": "Update annotated go install versions in Makefiles.",
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/.][^/]*\\.mk)$/"],
+      "managerFilePatterns": [
+        "/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/",
+        "!/(^|/)\\.env(?:\\.[^/]+)?$/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
       ]
@@ -68,7 +71,10 @@
     {
       "description": "Update annotated version variables in Makefiles.",
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/.][^/]*\\.mk)$/"],
+      "managerFilePatterns": [
+        "/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/",
+        "!/(^|/)\\.env(?:\\.[^/]+)?$/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
       ]

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -64,6 +64,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
       ]
+    },
+    {
+      "description": "Update annotated version variables in Makefiles.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
+      ]
     }
   ],
   "packageRules": [

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -60,7 +60,7 @@
     {
       "description": "Update annotated go install versions in Makefiles.",
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
+      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/.][^/]*\\.mk)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
       ]
@@ -68,7 +68,7 @@
     {
       "description": "Update annotated version variables in Makefiles.",
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
+      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/.][^/]*\\.mk)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
       ]

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -72,6 +72,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
       ]
+    },
+    {
+      "description": "Update annotated version variables in environment files.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)(?:\\.env(?:\\.[^/]+)?|[^/]+\\.env)$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*=[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
+      ]
     }
   ],
   "packageRules": [

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -60,31 +60,20 @@
     {
       "description": "Update annotated go install versions in Makefiles.",
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/",
-        "!/(^|/)\\.env(?:\\.[^/]+)?$/"
-      ],
+      "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
       ]
     },
     {
-      "description": "Update annotated version variables in Makefiles.",
+      "description": "Update annotated version variables in Makefiles and environment files.",
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/",
-        "!/(^|/)\\.env(?:\\.[^/]+)?$/"
+        "/(^|/)(?:\\.env(?:\\.[^/]+)?|[^/]+\\.env)$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
-      ]
-    },
-    {
-      "description": "Update annotated version variables in environment files.",
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:\\.env(?:\\.[^/]+)?|[^/]+\\.env)$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*=[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
       ]
     }
   ],

--- a/github-actions.json
+++ b/github-actions.json
@@ -6,6 +6,13 @@
       "description": ["Group third-party GitHub Actions non-major updates"],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["!Netcracker/**", "!netcracker/**"],
+      "matchDepNames": [
+        "!go",
+        "!golang",
+        "!docker.io/library/golang",
+        "!index.docker.io/library/golang",
+        "!registry-1.docker.io/library/golang"
+      ],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
       "groupName": "third-party GitHub Actions"
     },
@@ -13,6 +20,13 @@
       "description": ["Group third-party GitHub Actions major updates separately"],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["!Netcracker/**", "!netcracker/**"],
+      "matchDepNames": [
+        "!go",
+        "!golang",
+        "!docker.io/library/golang",
+        "!index.docker.io/library/golang",
+        "!registry-1.docker.io/library/golang"
+      ],
       "matchUpdateTypes": ["major"],
       "groupName": "major third-party GitHub Actions"
     },

--- a/go.json
+++ b/go.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": ["Group related Go dependency families without modifying unrelated modules"],
+  "description": ["Group related Go dependency families and toolchain versions without modifying unrelated dependencies"],
   "packageRules": [
     {
       "description": ["Group Kubernetes Go modules"],
@@ -21,9 +21,14 @@
       "groupName": "Prometheus Go modules"
     },
     {
-      "description": ["Group Go toolchain updates"],
-      "matchManagers": ["gomod"],
+      "description": ["Group Go toolchain versions"],
       "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": ["Group official Go builder images with Go toolchain updates"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["golang"],
       "groupName": "Go toolchain"
     }
   ]

--- a/go.json
+++ b/go.json
@@ -26,9 +26,22 @@
       "groupName": "Go toolchain"
     },
     {
+      "description": ["Group explicit GitHub Actions Go versions with Go toolchain updates"],
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["go"],
+      "matchPackageNames": ["actions/go-versions"],
+      "groupName": "Go toolchain"
+    },
+    {
       "description": ["Group official Go builder images with Go toolchain updates"],
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["golang"],
+      "matchPackageNames": [
+        "golang",
+        "docker.io/library/golang",
+        "index.docker.io/library/golang",
+        "registry-1.docker.io/library/golang"
+      ],
       "groupName": "Go toolchain"
     }
   ]

--- a/tests/fixtures/annotated-versions/kind.env
+++ b/tests/fixtures/annotated-versions/kind.env
@@ -1,0 +1,4 @@
+# renovate: datasource=github-releases depName=Netcracker/qubership-opensearch versioning=semver
+OPENSEARCH_VERSION=2.3.0
+
+UNANNOTATED_VERSION=1.0.0

--- a/tests/fixtures/annotated-versions/variables.mk
+++ b/tests/fixtures/annotated-versions/variables.mk
@@ -1,0 +1,4 @@
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools versioning=semver
+CONTROLLER_GEN_VERSION ?= v0.20.0
+
+UNANNOTATED_VERSION := v1.0.0


### PR DESCRIPTION
## Why

Repositories declare the Go toolchain in `go.mod`, GitHub Actions inputs, and builder images. Renovate should update these declarations together without grouping the `actions/setup-go` action version itself.

## What

- Group Go toolchain versions from `golang-version`, explicit `actions/setup-go` inputs, and official `golang` images.
- Support annotated version variables in Makefiles and environment files.
- Preserve annotated `go install` handling, including hidden Makefiles.
- Document and test the supported extraction behavior.

These are opt-in capability presets. The organization-inherited configuration is unchanged.

## Verification

The preset fixture suite covers real dependency shapes, image aliases, Makefile and environment extraction, and overlapping file names. The repository workflow runs the strict Renovate validator and the fixture suite.