### PR TITLE
fix(annotated-versions): preserve tag-only updates

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -36,7 +36,15 @@ function ruleMatchesDependency(rule, dependency) {
     ['matchDatasources', dependency.datasource],
     ['matchPackageNames', dependency.packageName ?? dependency.depName],
     ['matchDepNames', dependency.depName],
+    ['matchDepTypes', dependency.depType],
   ].every(([matcher, value]) => !rule[matcher] || rule[matcher].includes(value));
+}
+
+function applyPackageRules(dependency, rules) {
+  return rules.reduce(
+    (result, rule) => (ruleMatchesDependency(rule, dependency) ? { ...result, ...rule } : result),
+    dependency
+  );
 }
 
 function compileManager(manager) {
@@ -235,6 +243,102 @@ function assertRepositoryPolicy(config) {
 }
 
 function assertAnnotatedVersions(config) {
+  const alpineSyncManagerDescription = 'Keep Alpine Repology repositories in sync with the Alpine image.';
+  const annotatedManagers = config.customManagers.filter(
+    (manager) => manager.description !== alpineSyncManagerDescription
+  );
+  assert.equal(annotatedManagers.length, 7, 'All version-only annotation managers must be covered');
+  for (const manager of annotatedManagers) {
+    assert.equal(
+      manager.depTypeTemplate,
+      'annotated-version',
+      `${manager.description} must identify version-only dependencies`
+    );
+  }
+
+  const digestPinning = findRule(config, 'Disable digest pinning for version-only Docker annotations');
+  assert.deepEqual(digestPinning.matchManagers, ['custom.regex']);
+  assert.deepEqual(digestPinning.matchDatasources, ['docker']);
+  assert.deepEqual(digestPinning.matchDepTypes, ['annotated-version']);
+  assert.equal(digestPinning.pinDigests, false);
+
+  const versionOnlyDockerAnnotation = {
+    manager: 'custom.regex',
+    datasource: 'docker',
+    depName: 'graylog/graylog',
+    depType: 'annotated-version',
+  };
+  assert.equal(
+    ruleMatchesDependency(digestPinning, versionOnlyDockerAnnotation),
+    true,
+    'Version-only Docker annotations must match the digest override'
+  );
+
+  const inheritedDigestPinning = {
+    matchDatasources: ['docker'],
+    pinDigests: true,
+  };
+  assert.equal(
+    applyPackageRules(versionOnlyDockerAnnotation, [inheritedDigestPinning, ...config.packageRules]).pinDigests,
+    false,
+    'annotated-versions must override the base Docker digest policy when it is extended after base'
+  );
+  assert.equal(
+    applyPackageRules(versionOnlyDockerAnnotation, [...config.packageRules, inheritedDigestPinning]).pinDigests,
+    true,
+    'A later base Docker digest policy must override annotated-versions'
+  );
+
+  for (const testCase of [
+    {
+      manager: 'custom.regex',
+      datasource: 'docker',
+      depName: 'alpine',
+      depType: 'alpine-release-sync',
+      expectedPinDigests: false,
+    },
+    {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      depName: 'alpine',
+      depType: 'final',
+      expectedPinDigests: true,
+    },
+    {
+      manager: 'helm-values',
+      datasource: 'docker',
+      depName: 'graylog/graylog',
+      depType: 'docker',
+      expectedPinDigests: true,
+    },
+    {
+      manager: 'custom.regex',
+      datasource: 'docker',
+      depName: 'Netcracker/example',
+      depType: 'docker-image-with-digest',
+      expectedPinDigests: true,
+    },
+    {
+      manager: 'custom.regex',
+      datasource: 'github-releases',
+      depName: 'Netcracker/example',
+      depType: 'annotated-version',
+      expectedPinDigests: undefined,
+    },
+  ]) {
+    const { expectedPinDigests, ...dependency } = testCase;
+    assert.equal(
+      ruleMatchesDependency(digestPinning, dependency),
+      false,
+      `${dependency.manager}/${dependency.datasource}/${dependency.depType} must retain the inherited digest policy`
+    );
+    assert.equal(
+      applyPackageRules(dependency, [inheritedDigestPinning, ...config.packageRules]).pinDigests,
+      expectedPinDigests,
+      `${dependency.manager}/${dependency.datasource}/${dependency.depType} must keep its inherited policy value`
+    );
+  }
+
   const fixtures = [
     [
       'annotated-versions/Dockerfile',

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a team-specific preset:
   group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
-- `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands.
+- `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands. Version-only Docker annotations use tags without adding digests.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
 - `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`, including plugins whose Grafana API response contains only one release.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.
@@ -82,6 +82,10 @@ For example, a Go repository that uses annotated tool versions can compose these
 ```
 
 Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository decision.
+
+Keep `annotated-versions` after `base` in the `extends` list. The `base` preset enables digest pinning for Docker dependencies. The `annotated-versions` preset disables it only for version-only Docker annotations because those fields have nowhere to store a digest.
+
+Dependencies extracted by Renovate's native `dockerfile` and `helm-values` managers, along with custom managers that extract a digest, retain the inherited digest policy.
 
 ## Update Alpine package annotations with the base image
 

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -8,7 +8,8 @@
       "managerFilePatterns": ["/(^|/)(?:Dockerfile|Containerfile)(?:\\.[^/]+)?$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?(?: syncWith=alpine)?[^\\S\\r\\n]*\\r?\\n[\\t ]*ARG [A-Za-z_][A-Za-z0-9_]*[ =][\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Keep Alpine Repology repositories in sync with the Alpine image.",
@@ -31,7 +32,8 @@
       "managerFilePatterns": ["/(^|/).+\\.(?:ya?ml|ya?ml\\.tmpl|tmpl)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*[A-Za-z_][A-Za-z0-9_.-]*:[\\t ]*[\\\"']?(?<currentValue>[A-Za-z0-9][A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Update annotated image versions in Helm print templates.",
@@ -39,7 +41,8 @@
       "managerFilePatterns": ["/(^|/).+\\.tpl$/"],
       "matchStrings": [
         "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)\\\"[\\t ]*-?\\}\\}"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Update annotated commented image versions in YAML files.",
@@ -47,7 +50,8 @@
       "managerFilePatterns": ["/(^|/).+\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*#[\\t ]*dockerImage:[\\t ]+[^\\s:]+(?:/[^\\s:]+)*:(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Update annotated version directives in configuration files.",
@@ -55,7 +59,8 @@
       "managerFilePatterns": ["/(^|/).+\\.conf$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*version[\\t ]+(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Update annotated go install versions in Makefiles.",
@@ -63,7 +68,8 @@
       "managerFilePatterns": ["/(^|/)(?:Makefile|GNUMakefile|[^/]+\\.mk)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*go install [^\\s@]+@(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     },
     {
       "description": "Update annotated version variables in Makefiles and environment files.",
@@ -74,7 +80,8 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[^\\S\\r\\n]*\\r?\\n[\\t ]*(?:export[\\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\\t ]*(?::=|\\?=|=)[\\t ]*[\\\"']?(?<currentValue>v?\\d+[A-Za-z0-9._+-]*)[\\\"']?[^\\S\\r\\n]*"
-      ]
+      ],
+      "depTypeTemplate": "annotated-version"
     }
   ],
   "packageRules": [
@@ -87,6 +94,13 @@
     {
       "description": ["Disable digest pinning for Alpine repository synchronization"],
       "matchDepTypes": ["alpine-release-sync"],
+      "pinDigests": false
+    },
+    {
+      "description": ["Disable digest pinning for version-only Docker annotations"],
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchDepTypes": ["annotated-version"],
       "pinDigests": false
     },
     {


### PR DESCRIPTION
## Why

The organization baseline pins Docker digests. Version-only custom annotations cannot store a digest, so Renovate can fail while updating their branches.

This failure mode is tracked upstream in [renovatebot/renovate#24942](https://github.com/renovatebot/renovate/issues/24942).

## What

- Mark shared version-only annotations with a dedicated dependency type.
- Disable digest pinning only when that dependency type uses the Docker datasource.
- Preserve digest pinning for native Docker managers and digest-aware custom managers.
- Test preset order and document that `annotated-versions` must follow `base`.

## How to verify

- Run the `Validate Renovate Config` workflow.
- Confirm an annotated Docker version receives `pinDigests: false` while native `dockerfile` and `helm-values` dependencies retain `pinDigests: true`.