### PR TITLE
feat(annotated-versions): update pinned image digests

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -243,9 +243,8 @@ function assertRepositoryPolicy(config) {
 }
 
 function assertAnnotatedVersions(config) {
-  const alpineSyncManagerDescription = 'Keep Alpine Repology repositories in sync with the Alpine image.';
   const annotatedManagers = config.customManagers.filter(
-    (manager) => manager.description !== alpineSyncManagerDescription
+    (manager) => manager.depTypeTemplate === 'annotated-version'
   );
   assert.equal(annotatedManagers.length, 7, 'All version-only annotation managers must be covered');
   for (const manager of annotatedManagers) {
@@ -315,7 +314,7 @@ function assertAnnotatedVersions(config) {
       manager: 'custom.regex',
       datasource: 'docker',
       depName: 'Netcracker/example',
-      depType: 'docker-image-with-digest',
+      depType: 'annotated-docker-image',
       expectedPinDigests: true,
     },
     {
@@ -458,6 +457,82 @@ function assertAnnotatedVersions(config) {
     .filter((manager) => managerMatchesPath(manager, hiddenMakePath))
     .flatMap((manager) => extract(manager, hiddenMakeContent));
   assert.equal(hiddenMakeMatches.length, 1, `${hiddenMakePath} must preserve hidden Makefile support`);
+
+  const digestManagerDescription = 'Update digest-pinned images in Helm print templates.';
+  const digestManager = config.customManagers.find(
+    (manager) => manager.description === digestManagerDescription
+  );
+  assert.ok(digestManager, `Custom manager not found: ${digestManagerDescription}`);
+  assert.equal(digestManager.depTypeTemplate, 'annotated-docker-image');
+
+  const digestFixturePath =
+    'annotated-versions/logging/templates/graylog-image-digest.tpl';
+  const digestFixture = readFixture(digestFixturePath);
+  const digestMatches = config.customManagers
+    .filter((manager) => managerMatchesPath(manager, digestFixturePath))
+    .flatMap((manager) =>
+      extract(manager, digestFixture).map((dependency) => ({ dependency, manager }))
+    );
+  assert.equal(digestMatches.length, 1, `${digestFixturePath} must contain exactly one annotated dependency`);
+  assert.equal(digestMatches[0].manager.description, digestManagerDescription);
+  assert.deepEqual(
+    {
+      depName: digestMatches[0].dependency.depName,
+      datasource: digestMatches[0].dependency.datasource,
+      currentValue: digestMatches[0].dependency.currentValue,
+      currentDigest: digestMatches[0].dependency.currentDigest,
+    },
+    {
+      depName: 'graylog/graylog',
+      datasource: 'docker',
+      currentValue: '5.2.12',
+      currentDigest:
+        'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    }
+  );
+
+  const updatedDigestFixture = replaceRegexDependency(
+    digestManager,
+    digestFixture,
+    0,
+    '5.2.13',
+    'sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+  );
+  const updatedDigestDependencies = extract(digestManager, updatedDigestFixture);
+  assert.equal(updatedDigestDependencies.length, 1);
+  assert.equal(updatedDigestDependencies[0].currentValue, '5.2.13');
+  assert.equal(
+    updatedDigestDependencies[0].currentDigest,
+    'sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+  );
+  assert.match(
+    updatedDigestFixture,
+    /graylog\/graylog:5\.2\.13@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789/
+  );
+
+  const digestOnlyFixture = replaceRegexDependency(
+    digestManager,
+    digestFixture,
+    0,
+    '5.2.12',
+    'sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210'
+  );
+  const digestOnlyDependencies = extract(digestManager, digestOnlyFixture);
+  assert.equal(digestOnlyDependencies.length, 1);
+  assert.equal(digestOnlyDependencies[0].currentValue, '5.2.12');
+  assert.equal(
+    digestOnlyDependencies[0].currentDigest,
+    'sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210'
+  );
+
+  for (const currentValue of ['3.24', '1', 'jammy', 'latest']) {
+    const content =
+      '{{- /* # renovate: datasource=docker depName=alpine */ -}}\n' +
+      `{{- print "docker.io/alpine:${currentValue}@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" -}}\n`;
+    const dependencies = extract(digestManager, content);
+    assert.equal(dependencies.length, 1, `Docker tag ${currentValue} must be extracted`);
+    assert.equal(dependencies[0].currentValue, currentValue);
+  }
 }
 
 function assertAlpineRepologySync(config) {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a team-specific preset:
   group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
-- `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands. Version-only Docker annotations use tags without adding digests.
+- `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands. Version-only Docker annotations use tags without adding digests. Digest-pinned images in Helm print templates keep their tags and digests aligned.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
 - `grafana-plugins` updates Grafana plugin ID and version pairs in `plugins.list`, including plugins whose Grafana API response contains only one release.
 - `graylog-plugins` updates GitHub release URLs for Graylog plugin JARs in `plugins.list`.
@@ -86,6 +86,19 @@ Add `"github>Netcracker/renovate-config:go-tidy"` only as an explicit repository
 Keep `annotated-versions` after `base` in the `extends` list. The `base` preset enables digest pinning for Docker dependencies. The `annotated-versions` preset disables it only for version-only Docker annotations because those fields have nowhere to store a digest.
 
 Dependencies extracted by Renovate's native `dockerfile` and `helm-values` managers, along with custom managers that extract a digest, retain the inherited digest policy.
+
+### Pin annotated Helm image defaults by digest
+
+Add a digest to a full image reference in a Helm print template to opt in to digest updates:
+
+```gotemplate
+{{- /* # renovate: datasource=docker depName=graylog/graylog */ -}}
+{{- print "docker.io/graylog/graylog:5.2.12@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" -}}
+```
+
+Renovate extracts both the tag and digest and updates them together. A template that contains only a tag continues to receive tag-only updates.
+
+Seed the first valid digest manually. The preset requires an existing `@sha256:...` value instead of relying on initial digest insertion by a regex manager, which remains tracked in [renovatebot/renovate#10993](https://github.com/renovatebot/renovate/issues/10993).
 
 ## Update Alpine package annotations with the base image
 

--- a/annotated-versions.json
+++ b/annotated-versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": ["Update explicitly annotated version values in supported text files"],
+  "description": ["Update explicitly annotated dependency values in supported text files"],
   "customManagers": [
     {
       "description": "Update annotated Docker ARG version values.",
@@ -43,6 +43,15 @@
         "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:[-+][A-Za-z0-9._-]+)?)\\\"[\\t ]*-?\\}\\}"
       ],
       "depTypeTemplate": "annotated-version"
+    },
+    {
+      "description": "Update digest-pinned images in Helm print templates.",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).+\\.tpl$/"],
+      "matchStrings": [
+        "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>docker) depName=(?<depName>[^\\s]+)(?: packageName=(?<packageName>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})@(?<currentDigest>sha256:[a-f0-9]{64})\\\"[\\t ]*-?\\}\\}"
+      ],
+      "depTypeTemplate": "annotated-docker-image"
     },
     {
       "description": "Update annotated commented image versions in YAML files.",

--- a/tests/fixtures/annotated-versions/logging/templates/graylog-image-digest.tpl
+++ b/tests/fixtures/annotated-versions/logging/templates/graylog-image-digest.tpl
@@ -1,0 +1,2 @@
+{{- /* # renovate: datasource=docker depName=graylog/graylog */ -}}
+{{- print "docker.io/graylog/graylog:5.2.12@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" -}}


### PR DESCRIPTION
## Why

PR [#32](https://github.com/Netcracker/renovate-config/pull/32) prevents update failures by disabling digest pinning for version-only annotations. Helm print templates that already contain `tag@sha256` can store both values and should retain the organization digest policy.

This design avoids the version-only update failure tracked in [renovatebot/renovate#24942](https://github.com/renovatebot/renovate/issues/24942). It requires a manually seeded digest because initial digest insertion by a regex manager remains tracked in [renovatebot/renovate#10993](https://github.com/renovatebot/renovate/issues/10993).

## What

- Add a dedicated `annotated-docker-image` manager for digest-pinned Helm print templates.
- Support valid Docker tags, including semantic, short, channel, and mutable tags.
- Keep version-only annotations on the existing tag-only path.
- Test tag-and-digest and digest-only updates.
- Document the opt-in format and initial digest requirement.

## How to verify

- Confirm the fixture extracts both `currentValue` and `currentDigest` without matching the version-only manager.
- Confirm tag-and-digest and digest-only replacement tests pass.
- Run the `Validate Renovate Config` workflow.