### PR TITLE
feat(maven): group updates by groupId

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -6,6 +6,7 @@ const presetNames = [
   'github-actions',
   'go',
   'go-tidy',
+  'maven-groupid',
   'netcracker-dependencies',
   'test-pipelines',
   'annotated-versions',
@@ -30,6 +31,25 @@ function findRule(config, description) {
   return rule;
 }
 
+function matchesStringPattern(pattern, value) {
+  if (pattern.startsWith('/') && pattern.endsWith('/')) {
+    return new RegExp(pattern.slice(1, -1)).test(value);
+  }
+  if (pattern.endsWith('/**')) {
+    return value.startsWith(pattern.slice(0, -2));
+  }
+  return pattern === value;
+}
+
+function matchesStringPatterns(patterns, value) {
+  const negativePatterns = patterns.filter((pattern) => pattern.startsWith('!')).map((pattern) => pattern.slice(1));
+  if (negativePatterns.some((pattern) => matchesStringPattern(pattern, value))) {
+    return false;
+  }
+  const positivePatterns = patterns.filter((pattern) => !pattern.startsWith('!'));
+  return positivePatterns.length === 0 || positivePatterns.some((pattern) => matchesStringPattern(pattern, value));
+}
+
 function ruleMatchesDependency(rule, dependency) {
   return [
     ['matchManagers', dependency.manager],
@@ -37,7 +57,7 @@ function ruleMatchesDependency(rule, dependency) {
     ['matchPackageNames', dependency.packageName ?? dependency.depName],
     ['matchDepNames', dependency.depName],
     ['matchDepTypes', dependency.depType],
-  ].every(([matcher, value]) => !rule[matcher] || rule[matcher].includes(value));
+  ].every(([matcher, value]) => !rule[matcher] || matchesStringPatterns(rule[matcher], value));
 }
 
 function applyPackageRules(dependency, rules) {
@@ -78,7 +98,14 @@ function replaceRegexDependency(manager, content, dependencyIndex, newValue, new
 
 function render(template, values) {
   return template
-    .replaceAll(/\{\{\{replace '\^v' '' ([^}]+)}}}/g, (_, field) => (values[field] ?? '').replace(/^v/, ''))
+    .replaceAll(
+      /\{\{#if \(equals ([^ ]+) '([^']+)'\)\}\}([\s\S]*?)\{\{else\}\}([\s\S]*?)\{\{\/if\}\}/g,
+      (_, field, expected, ifTrue, ifFalse) => (values[field] === expected ? ifTrue : ifFalse)
+    )
+    .replaceAll(
+      /\{\{\{replace '([^']+)' '([^']*)' ([^}]+)}}}/g,
+      (_, pattern, replacement, field) => (values[field] ?? '').replace(new RegExp(pattern), replacement)
+    )
     .replaceAll(/\{\{\{([^}]+)}}}/g, (_, field) => values[field] ?? '');
 }
 
@@ -224,6 +251,66 @@ function assertNetcrackerPolicy(config) {
   const majorActions = findRule(config, 'Group major Netcracker GitHub Actions updates separately');
   assert.deepEqual(majorActions.matchUpdateTypes, ['major']);
   assert.equal(majorActions.minimumReleaseAge, '0 days');
+}
+
+function assertMavenGroupIdPolicy(config, netcrackerConfig) {
+  const defaultRule = findRule(config, 'Group Maven updates by groupId');
+  assert.deepEqual(defaultRule.matchDatasources, ['maven']);
+
+  const junitApi = render(defaultRule.groupName, {
+    datasource: 'maven',
+    depName: 'org.junit.jupiter:junit-jupiter-api',
+  });
+  const junitEngine = render(defaultRule.groupName, {
+    datasource: 'maven',
+    depName: 'org.junit.jupiter:junit-jupiter-engine',
+  });
+  assert.equal(junitApi, 'org.junit.jupiter');
+  assert.equal(junitEngine, junitApi, 'Maven artifacts with the same groupId must share a group');
+  assert.notEqual(
+    render(defaultRule.groupName, {
+      datasource: 'maven',
+      depName: 'org.junit.platform:junit-platform-launcher',
+    }),
+    junitApi,
+    'Different Maven groupIds must stay in separate groups'
+  );
+
+  const vulnerabilityGroup = config.vulnerabilityAlerts?.groupName;
+  assert.ok(vulnerabilityGroup, 'Maven vulnerability updates must define a group');
+  assert.equal(
+    render(vulnerabilityGroup, {
+      datasource: 'maven',
+      depName: 'org.apache.logging.log4j:log4j-core',
+    }),
+    'org.apache.logging.log4j security'
+  );
+  assert.notEqual(
+    render(vulnerabilityGroup, {
+      datasource: 'docker',
+      depName: 'ghcr.io/netcracker/example',
+    }),
+    render(vulnerabilityGroup, {
+      datasource: 'go',
+      depName: 'ghcr.io/netcracker/example',
+    }),
+    'Non-Maven vulnerability groups must remain distinct across datasources'
+  );
+
+  const internalDependency = {
+    manager: 'maven',
+    datasource: 'maven',
+    depName: 'org.qubership.profiler:agent',
+    packageName: 'org.qubership.profiler:agent',
+  };
+  const internalRule = findRule(netcrackerConfig, 'Group Netcracker Maven artifacts');
+  const result = applyPackageRules(internalDependency, [defaultRule, internalRule]);
+  assert.equal(result.groupName, 'Netcracker Maven artifacts');
+  assert.equal(
+    render(vulnerabilityGroup, internalDependency),
+    'org.qubership.profiler security',
+    'Vulnerability updates must use the Maven groupId even for internal artifacts'
+  );
 }
 
 function assertNoAutomerge(configs) {
@@ -620,6 +707,7 @@ assertBasePolicy(configs.base);
 assertGitHubActionsPolicy(configs['github-actions']);
 assertGoPolicy(configs.go);
 assertGoTidyPolicy(configs['go-tidy']);
+assertMavenGroupIdPolicy(configs['maven-groupid'], configs['netcracker-dependencies']);
 assertNetcrackerPolicy(configs['netcracker-dependencies']);
 assertTestPipelines(configs['test-pipelines']);
 assertAnnotatedVersions(configs['annotated-versions']);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ a team-specific preset:
   `go.mod` directives, explicit GitHub Actions Go versions, and official `golang` builder images. The preset does not
   group unrelated dependencies or the `actions/setup-go` action version.
 - `go-tidy` runs `go mod tidy` after Go module updates.
+- `maven-groupid` groups Maven updates by `groupId`. Maven vulnerability updates use the same grouping, while
+  vulnerability updates from other ecosystems remain separate by datasource and dependency.
 - `netcracker-dependencies` groups internal dependencies by ecosystem and removes their release-age delay.
 - `annotated-versions` updates annotated Docker, YAML, template, Makefile, and environment values and `go install` commands. Version-only Docker annotations use tags without adding digests.
 - `test-pipelines` keeps reusable test pipeline workflow references and `pipeline_branch` inputs aligned.
@@ -66,6 +68,38 @@ a team-specific preset:
 
 The `go-tidy` preset is separate because `gomodTidy` can make changes to `go.mod` and `go.sum` that are unrelated to
 the dependency Renovate is updating. Enable it only when those broader module-file changes are acceptable.
+
+## Group Maven updates by groupId
+
+Enable the `maven-groupid` preset to group Maven artifacts that share a `groupId`:
+
+```json
+{
+  "extends": ["github>Netcracker/renovate-config:maven-groupid"]
+}
+```
+
+For example, updates for `org.apache.logging.log4j:log4j-api` and
+`org.apache.logging.log4j:log4j-core` use one `org.apache.logging.log4j` group. The preset applies the same grouping to
+Maven vulnerability updates.
+
+Repository package rules can override the default group. Keep local rules that combine multiple groupIds, constrain
+versions, or apply only to specific files.
+
+For ordinary updates, place `netcracker-dependencies` after `maven-groupid` so internal Maven artifacts retain the
+shared `Netcracker Maven artifacts` group:
+
+```json
+{
+  "extends": [
+    "github>Netcracker/renovate-config:maven-groupid",
+    "github>Netcracker/renovate-config:netcracker-dependencies"
+  ]
+}
+```
+
+Vulnerability updates always use the `<groupId> security` group, including internal artifacts. Renovate applies
+`vulnerabilityAlerts` after ordinary package rules, so preset order does not change security grouping.
 
 For example, a Go repository that uses annotated tool versions can compose these presets:
 

--- a/maven-groupid.json
+++ b/maven-groupid.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Group Maven updates by groupId"],
+  "vulnerabilityAlerts": {
+    "description": ["Group Maven vulnerability updates by groupId without combining other ecosystems"],
+    "groupName": "{{#if (equals datasource 'maven')}}{{{replace ':.*' '' depName}}} security{{else}}{{{datasource}}} {{{depName}}} security{{/if}}"
+  },
+  "packageRules": [
+    {
+      "description": ["Group Maven updates by groupId"],
+      "matchDatasources": ["maven"],
+      "groupName": "{{{replace ':.*' '' depName}}}"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Maven artifacts from the same project often share a version and should be updated together. Repositories currently need a separate package rule for every Maven `groupId`, and missing rules can split related updates into separate PRs, including security fixes.

## What

- Add the opt-in `maven-groupid` preset.
- Group artifacts by Maven `groupId`. For example, `org.apache.logging.log4j:log4j-api` and `org.apache.logging.log4j:log4j-core` are updated in one PR.
- Apply the same grouping to Maven vulnerability updates.
- Keep repository-specific rules able to override the default grouping.
- Document and test composition with `netcracker-dependencies`.

The preset is opt-in. This PR does not change inherited configuration or existing repository behavior.

## How to verify

- Run `node .github/scripts/test-presets.mjs`.
- Run the `Validate Renovate Config` workflow.
