### PR TITLE
feat(go): add opt-in catch-all grouping preset

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -5,6 +5,7 @@ const presetNames = [
   'base',
   'github-actions',
   'go',
+  'go-catch-all',
   'go-tidy',
   'maven-groupid',
   'netcracker-dependencies',
@@ -57,6 +58,7 @@ function ruleMatchesDependency(rule, dependency) {
     ['matchPackageNames', dependency.packageName ?? dependency.depName],
     ['matchDepNames', dependency.depName],
     ['matchDepTypes', dependency.depType],
+    ['matchUpdateTypes', dependency.updateType],
   ].every(([matcher, value]) => !rule[matcher] || matchesStringPatterns(rule[matcher], value));
 }
 
@@ -226,6 +228,61 @@ function assertGoTidyPolicy(config) {
   const rule = findRule(config, 'Run go mod tidy after Go module updates');
   assert.deepEqual(rule.matchManagers, ['gomod']);
   assert.deepEqual(rule.postUpdateOptions, ['gomodTidy']);
+}
+
+function assertGoCatchAllPolicy(config) {
+  const rule = findRule(config, 'Group other Go module minor and patch updates');
+  assert.deepEqual(rule.matchManagers, ['gomod']);
+  assert.deepEqual(rule.matchDatasources, ['go']);
+  assert.deepEqual(rule.matchUpdateTypes, ['minor', 'patch']);
+  assert.deepEqual(rule.matchPackageNames, [
+    '!k8s.io/**',
+    '!sigs.k8s.io/**',
+    '!github.com/openshift/**',
+    '!go.opentelemetry.io/**',
+    '!github.com/open-telemetry/**',
+    '!github.com/prometheus/**',
+    '!github.com/Netcracker/**',
+  ]);
+  assert.equal(rule.groupName, 'Other Go modules');
+
+  assert.equal(
+    ruleMatchesDependency(rule, {
+      manager: 'gomod',
+      datasource: 'go',
+      packageName: 'github.com/stretchr/testify',
+      updateType: 'minor',
+    }),
+    true,
+    'Unrelated Go module minor updates must join the catch-all group'
+  );
+  for (const packageName of [
+    'k8s.io/client-go',
+    'go.opentelemetry.io/otel',
+    'github.com/prometheus/client_golang',
+    'github.com/Netcracker/qubership-core-lib-go',
+  ]) {
+    assert.equal(
+      ruleMatchesDependency(rule, {
+        manager: 'gomod',
+        datasource: 'go',
+        packageName,
+        updateType: 'minor',
+      }),
+      false,
+      `${packageName} must retain its capability-preset group`
+    );
+  }
+  assert.equal(
+    ruleMatchesDependency(rule, {
+      manager: 'gomod',
+      datasource: 'go',
+      packageName: 'github.com/stretchr/testify',
+      updateType: 'major',
+    }),
+    false,
+    'Major updates must remain separate from the catch-all group'
+  );
 }
 
 function assertNetcrackerPolicy(config) {
@@ -781,6 +838,7 @@ assertRepositoryPolicy(readJson('renovate.json'));
 assertBasePolicy(configs.base);
 assertGitHubActionsPolicy(configs['github-actions']);
 assertGoPolicy(configs.go);
+assertGoCatchAllPolicy(configs['go-catch-all']);
 assertGoTidyPolicy(configs['go-tidy']);
 assertMavenGroupIdPolicy(configs['maven-groupid'], configs['netcracker-dependencies']);
 assertNetcrackerPolicy(configs['netcracker-dependencies']);

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ a team-specific preset:
 - `go` groups Kubernetes and OpenShift, OpenTelemetry, Prometheus, and Go toolchain updates. Toolchain updates include
   `go.mod` directives, explicit GitHub Actions Go versions, and official `golang` builder images. The preset does not
   group unrelated dependencies or the `actions/setup-go` action version.
+- `go-catch-all` groups minor and patch updates for Go modules not covered by the `go` or `netcracker-dependencies`
+  presets. Major updates remain separate.
 - `go-tidy` runs `go mod tidy` after Go module updates.
 - `maven-groupid` groups Maven updates by `groupId`. Maven vulnerability updates use the same grouping, while
   vulnerability updates from other ecosystems remain separate by datasource and dependency.
@@ -68,6 +70,19 @@ a team-specific preset:
 
 The `go-tidy` preset is separate because `gomodTidy` can make changes to `go.mod` and `go.sum` that are unrelated to
 the dependency Renovate is updating. Enable it only when those broader module-file changes are acceptable.
+
+The `go-catch-all` preset is separate because grouping unrelated Go modules trades smaller PR volume for a larger
+validation scope. Enable it only when the repository wants one PR for unrelated minor and patch updates:
+
+```json
+{
+  "extends": [
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "github>Netcracker/renovate-config:go-catch-all"
+  ]
+}
+```
 
 ## Group Maven updates by groupId
 

--- a/go-catch-all.json
+++ b/go-catch-all.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": ["Group minor and patch updates for Go modules not covered by the shared capability groups"],
+  "packageRules": [
+    {
+      "description": ["Group other Go module minor and patch updates"],
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchPackageNames": [
+        "!k8s.io/**",
+        "!sigs.k8s.io/**",
+        "!github.com/openshift/**",
+        "!go.opentelemetry.io/**",
+        "!github.com/open-telemetry/**",
+        "!github.com/prometheus/**",
+        "!github.com/Netcracker/**"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Other Go modules"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add an opt-in `go-catch-all` preset for unrelated Go module minor and patch updates.
- Keep major updates separate and preserve the existing Kubernetes, OpenTelemetry, Prometheus, and Netcracker groups.
- Document the preset and test its matching behavior.

## Why

Several repositories duplicate this catch-all rule locally. A separate opt-in preset removes that duplication without changing existing consumers.

## Validation

- `node .github/scripts/test-presets.mjs`
- Strict Renovate config validation for all repository presets.
