### PR TITLE
fix(github-actions): suppress broken profanity-filter lookup

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -52,7 +52,7 @@ function matchesStringPatterns(patterns, value) {
 }
 
 function ruleMatchesDependency(rule, dependency) {
-  return [
+  const arrayMatchersMatch = [
     ['matchManagers', dependency.manager],
     ['matchDatasources', dependency.datasource],
     ['matchPackageNames', dependency.packageName ?? dependency.depName],
@@ -60,6 +60,9 @@ function ruleMatchesDependency(rule, dependency) {
     ['matchDepTypes', dependency.depType],
     ['matchUpdateTypes', dependency.updateType],
   ].every(([matcher, value]) => !rule[matcher] || matchesStringPatterns(rule[matcher], value));
+  const currentValueMatches =
+    !rule.matchCurrentValue || matchesStringPatterns([rule.matchCurrentValue], dependency.currentValue);
+  return arrayMatchersMatch && currentValueMatches;
 }
 
 function applyPackageRules(dependency, rules) {
@@ -413,6 +416,56 @@ function assertRepositoryPolicy(config) {
   assert.ok(
     config.extends?.includes(':ignoreModulesAndTests'),
     'renovate.json must ignore test and fixture dependency files'
+  );
+}
+
+function assertOrgInheritedPolicy(config) {
+  const profanityFilterAction = {
+    manager: 'github-actions',
+    datasource: 'github-tags',
+    packageName: 'IEvangelist/profanity-filter',
+    currentValue: 'v13.4.6',
+  };
+  assert.equal(
+    applyPackageRules(profanityFilterAction, config.packageRules).enabled,
+    false,
+    'The known broken extracted Action version must be disabled'
+  );
+  assert.equal(
+    applyPackageRules({ ...profanityFilterAction, currentValue: '13.4.6' }, config.packageRules).enabled,
+    false,
+    'The broken version without a v prefix must also be disabled'
+  );
+  assert.equal(
+    applyPackageRules({ ...profanityFilterAction, currentValue: 'v13.4.7' }, config.packageRules).enabled,
+    undefined,
+    'Other versions of the same Action must remain enabled'
+  );
+  assert.equal(
+    applyPackageRules(
+      { ...profanityFilterAction, packageName: 'actions/checkout' },
+      config.packageRules
+    ).enabled,
+    undefined,
+    'Other GitHub Actions must remain enabled'
+  );
+  assert.equal(
+    applyPackageRules(
+      { ...profanityFilterAction, manager: 'custom.regex' },
+      config.packageRules
+    ).enabled,
+    undefined,
+    'The exception must apply only to the GitHub Actions manager'
+  );
+  const projectOverride = {
+    matchManagers: ['github-actions'],
+    matchPackageNames: ['IEvangelist/profanity-filter'],
+    enabled: true,
+  };
+  assert.equal(
+    applyPackageRules(profanityFilterAction, [...config.packageRules, projectOverride]).enabled,
+    true,
+    'A later repository rule must be able to re-enable the Action after a compatible release is available'
   );
 }
 
@@ -884,6 +937,7 @@ function assertGraylogPlugins(config) {
 
 const configs = Object.fromEntries(presetNames.map((name) => [name, readJson(`${name}.json`)]));
 assertRepositoryPolicy(readJson('renovate.json'));
+assertOrgInheritedPolicy(readJson('org-inherited-config.json'));
 assertBasePolicy(configs.base);
 assertGitHubActionsPolicy(configs['github-actions']);
 assertGoPolicy(configs.go);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ for every repository in the organization.
 - Go toolchain and official `golang.org/x/*` updates bypass the delay. Other Go module dependencies keep the standard
   seven-day delay.
 - Groups all `actions/*` GitHub Actions updates into a single PR titled `actions org`.
+- Temporarily disables Renovate updates for the SHA-pinned `IEvangelist/profanity-filter` Action only when Renovate
+  extracts the broken `13.4.6` or `v13.4.6` value from its four-component version comment. Other versions remain
+  enabled. Remove this exception after the exact published tag or alias resolves successfully and the shared workflow
+  uses that reference. Upstream progress is tracked in
+  [IEvangelist/profanity-filter#168](https://github.com/IEvangelist/profanity-filter/issues/168).
 
 ## Overriding for a specific repository
 

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -15,6 +15,13 @@
   },
   "packageRules": [
     {
+      "description": ["Disable the broken IEvangelist/profanity-filter v13.4.6 lookup until its SHA-pinned GitHub Action supports Renovate-compatible version comments (IEvangelist/profanity-filter#168)"],
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["IEvangelist/profanity-filter"],
+      "matchCurrentValue": "/^v?13\\.4\\.6$/",
+      "enabled": false
+    },
+    {
       "description": ["Group all actions/* GitHub Actions into a single PR"],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/**"],


### PR DESCRIPTION
## Why

Renovate truncates the SHA-pinned `IEvangelist/profanity-filter` version comments `13.4.6.2` and `v13.4.6.2` to nonexistent `13.4.6` and `v13.4.6` tags. This produces dependency lookup warnings in repositories that use the shared workflow. Upstream tracking: [IEvangelist/profanity-filter#168](https://github.com/IEvangelist/profanity-filter/issues/168).

## What

- Temporarily disable this dependency only for the `github-actions` manager and the two broken extracted values.
- Keep other versions, GitHub Actions, and managers enabled.
- Allow a later repository rule or security force rule to re-enable the dependency.
- Document the removal condition and test the inherited policy.

The rule applies organization-wide. While it matches, normal SHA updates for this Action remain disabled, but the existing lookup failure already prevents those updates. Remove the rule after a resolvable tag or alias is published and the shared workflow uses it.

## Validation

- All 14 shared configs and the repository config pass strict Renovate validation.
- Preset behavior tests cover both broken values, a different version, another Action, another manager, and a later repository override.
- Renovate 44.0.1 dry runs confirm that both broken values are disabled without a lookup warning.
- Independent review found no remaining issues.
