### PR TITLE
fix(apm): preserve marketplace entries during updates

### DIFF
--- a/.github/scripts/validate-apm-regex.mjs
+++ b/.github/scripts/validate-apm-regex.mjs
@@ -61,14 +61,53 @@ for (const manager of [marketReleaseManager, marketBranchManager]) {
   if (!hasNamedDigest(manager)) {
     throw new Error(`Marketplace manager ${JSON.stringify(manager.description)} must keep the SHA pin (currentDigest)`);
   }
-  if (!manager.autoReplaceStringTemplate.includes('newDigest')) {
-    throw new Error(`Marketplace manager ${JSON.stringify(manager.description)} must update the digest via newDigest`);
-  }
 }
 
-function applyTemplate(manager, match, { newDigest, newValue }) {
-  const templateValues = { ...match.groups, newDigest, newValue };
-  return manager.autoReplaceStringTemplate.replaceAll(/\{\{\{([^}]+)}}}/g, (_, field) => templateValues[field] ?? '');
+// Renovate discards arbitrary capture groups after extraction. Auto-replace templates receive only these fields.
+const runtimeFields = [
+  'currentDigest',
+  'currentValue',
+  'datasource',
+  'depName',
+  'depType',
+  'extractVersion',
+  'indentation',
+  'packageName',
+  'registryUrl',
+  'versioning',
+];
+
+function render(template, values) {
+  return template.replaceAll(/\{\{\{([^}]+)}}}/g, (_, field) => values[field] ?? '');
+}
+
+function extractRuntimeDependency(manager, match) {
+  const dependency = {};
+  for (const field of runtimeFields) {
+    const template = manager[`${field}Template`];
+    const value = template ? render(template, match.groups) : match.groups[field];
+    if (value !== undefined) {
+      dependency[field] = value;
+    }
+  }
+  dependency.replaceString = match[0];
+  return dependency;
+}
+
+function replaceDependency(manager, match, update) {
+  const dependency = extractRuntimeDependency(manager, match);
+  if (manager.autoReplaceStringTemplate) {
+    return render(manager.autoReplaceStringTemplate, { ...dependency, ...update });
+  }
+
+  let replacement = match[0];
+  if (dependency.currentValue && update.newValue) {
+    replacement = replacement.replace(dependency.currentValue, update.newValue);
+  }
+  if (dependency.currentDigest && update.newDigest) {
+    replacement = replacement.replace(dependency.currentDigest, update.newDigest);
+  }
+  return replacement;
 }
 
 function firstMatch(manager, content) {
@@ -80,7 +119,7 @@ function replaceFirstMatch(manager, content, update) {
   if (!match) {
     throw new Error(`Manager ${JSON.stringify(manager.description)} matched nothing in the fixture`);
   }
-  const replacement = applyTemplate(manager, match, update);
+  const replacement = replaceDependency(manager, match, update);
   return `${content.slice(0, match.index)}${replacement}${content.slice(match.index + match[0].length)}`;
 }
 
@@ -126,7 +165,7 @@ const branchDependencyMatch = firstMatch(depsManager, branchDependencyFixture);
 if (branchDependencyMatch?.groups.currentValue !== 'main') {
   throw new Error(`Dependencies manager must read the branch name, got ${JSON.stringify(branchDependencyMatch?.groups.currentValue)}`);
 }
-const collapsedBranch = applyTemplate(depsManager, branchDependencyMatch, { newValue: 'main' });
+const collapsedBranch = replaceDependency(depsManager, branchDependencyMatch, { newValue: 'main' });
 if (/[0-9a-f]{40}/.test(collapsedBranch) || collapsedBranch.includes('  # ')) {
   throw new Error(`Collapsing a branch dependency must drop the digest, got: ${JSON.stringify(collapsedBranch)}`);
 }
@@ -200,6 +239,42 @@ if (!bumpedBranch.includes(`ref: ${newDigest}  # main`) || bumpedBranch.includes
 }
 if (firstMatch(marketBranchManager, marketReleaseFixture)) {
   throw new Error('Marketplace branch manager must not match a version-tag ref');
+}
+
+// Updating one grouped dependency must preserve every marketplace entry and its extraction order.
+const groupedBranchFixture = `marketplace:
+  packages:
+    - name: api-diff-authoring
+      source: Netcracker/qubership-apihub-api-diff
+      subdir: agent-packages/api-diff-authoring
+      ref: 7b0bf733df7288bf051ec2e5719d7ffc2753566f  # develop
+
+    - name: api-unifier-authoring
+      source: Netcracker/qubership-apihub-api-unifier
+      subdir: agent-packages/api-unifier-authoring
+      ref: 635ce729bd94f42a61a1c036bc3b066a20ab7755  # develop
+
+    - name: api-unifier-testing
+      source: Netcracker/qubership-apihub-api-unifier
+      subdir: agent-packages/api-unifier-testing
+      ref: 635ce729bd94f42a61a1c036bc3b066a20ab7755  # develop
+`;
+const groupedMatches = [...groupedBranchFixture.matchAll(new RegExp(marketBranchManager.matchStrings[0], 'g'))];
+const groupedDepNames = groupedMatches.map((match) => extractRuntimeDependency(marketBranchManager, match).depName);
+const updatedFirstBranch = replaceFirstMatch(marketBranchManager, groupedBranchFixture, {
+  newDigest: '29c324bf6e893195c8c87eb1b5992947b7f64d6f',
+});
+const updatedGroupedMatches = [...updatedFirstBranch.matchAll(new RegExp(marketBranchManager.matchStrings[0], 'g'))];
+const updatedGroupedDepNames = updatedGroupedMatches.map(
+  (match) => extractRuntimeDependency(marketBranchManager, match).depName
+);
+if (JSON.stringify(updatedGroupedDepNames) !== JSON.stringify(groupedDepNames)) {
+  throw new Error(
+    `Marketplace branch update changed dependency extraction from ${JSON.stringify(groupedDepNames)} to ${JSON.stringify(updatedGroupedDepNames)}`
+  );
+}
+if (!updatedFirstBranch.includes('ref: 29c324bf6e893195c8c87eb1b5992947b7f64d6f  # develop')) {
+  throw new Error(`Marketplace branch update did not preserve the package block:\n${updatedFirstBranch}`);
 }
 
 // Captured values must span the whole ref token, so a malformed value never leaves a suffix behind.

--- a/.github/scripts/validate-apm-regex.mjs
+++ b/.github/scripts/validate-apm-regex.mjs
@@ -61,10 +61,13 @@ for (const manager of [marketReleaseManager, marketBranchManager]) {
   if (!hasNamedDigest(manager)) {
     throw new Error(`Marketplace manager ${JSON.stringify(manager.description)} must keep the SHA pin (currentDigest)`);
   }
+  if (manager.matchStrings.some((matchString) => matchString.includes('(?<depPrefix>'))) {
+    throw new Error(`Marketplace manager ${JSON.stringify(manager.description)} must not capture unused depPrefix`);
+  }
 }
 
-// Renovate discards arbitrary capture groups after extraction. Auto-replace templates receive only these fields.
-const runtimeFields = [
+// Renovate keeps only these fields from the regex captures; every other group is dropped at extraction.
+const extractedFields = [
   'currentDigest',
   'currentValue',
   'datasource',
@@ -83,7 +86,7 @@ function render(template, values) {
 
 function extractRuntimeDependency(manager, match) {
   const dependency = {};
-  for (const field of runtimeFields) {
+  for (const field of extractedFields) {
     const template = manager[`${field}Template`];
     const value = template ? render(template, match.groups) : match.groups[field];
     if (value !== undefined) {
@@ -261,6 +264,9 @@ const groupedBranchFixture = `marketplace:
 `;
 const groupedMatches = [...groupedBranchFixture.matchAll(new RegExp(marketBranchManager.matchStrings[0], 'g'))];
 const groupedDepNames = groupedMatches.map((match) => extractRuntimeDependency(marketBranchManager, match).depName);
+if (groupedDepNames.length !== 3) {
+  throw new Error(`Grouped marketplace fixture must yield three dependencies, got ${JSON.stringify(groupedDepNames)}`);
+}
 const updatedFirstBranch = replaceFirstMatch(marketBranchManager, groupedBranchFixture, {
   newDigest: '29c324bf6e893195c8c87eb1b5992947b7f64d6f',
 });

--- a/README.md
+++ b/README.md
@@ -227,18 +227,20 @@ pipeline_branch: 'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8' # v1.14.1 renovate: 
 
 ## `apm.json` preset
 
-[`apm.json`](./apm.json) detects APM package references in `apm.yml` files and proposes semantic-version bumps for
-tag-tracked entries via the `github-tags` datasource. It covers the `dependencies.apm` list (`package#v1.2.0`) and the
-`marketplace.packages` block (`ref: v1.2.0`).
+[`apm.json`](./apm.json) detects APM package references in `apm.yml` files. It handles dependencies and marketplace
+sources differently because only dependencies are covered by `apm.lock.yaml`.
 
 Design notes:
 
-- `apm.yml` records only a version tag or a branch name. Resolved commit SHAs live in `apm.lock.yaml`, produced by
-  `apm install`, not in `apm.yml`.
-- Tag refs advance to newer semantic-version tags (for example `v0.1.0` → `v1.0.1`).
-- Branch refs (`package#main`, `ref: main`) are left untouched; a branch carries no version to bump.
-- When an entry still carries a legacy `#<sha>  # v0.1.0` pin, the first tag bump rewrites it to a clean `#v0.1.0` and
-  drops the SHA. The preset never writes a digest back into `apm.yml`.
+- Dependencies use a tag such as `package#v1.2.0`. Renovate advances the tag, while `apm.lock.yaml` stores the resolved
+  commit SHA. Dependency branch refs such as `package#main` remain unchanged.
+- A legacy dependency pin such as `package#<sha>  # v1.2.0` becomes `package#v1.3.0` on its first tag update. The
+  dependency SHA remains in `apm.lock.yaml`.
+- Marketplace sources use an immutable SHA with a source-ref comment, such as `ref: <sha>  # v1.2.0` or
+  `ref: <sha>  # main`, because `apm.lock.yaml` does not cover these entries.
+- Marketplace release updates change both the SHA and the semantic-version tag. Marketplace branch updates change the
+  SHA to the branch head and keep the branch comment.
+- APM updates remain under manual review.
 
 Use it from a repository-local config:
 

--- a/apm.json
+++ b/apm.json
@@ -25,8 +25,7 @@
       "versioningTemplate": "semver",
       "depNameTemplate": "{{{packageName}}}/{{{apmSubdir}}}",
       "packageNameTemplate": "{{{packageName}}}",
-      "depTypeTemplate": "apm",
-      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{newDigest}}}  # {{{newValue}}}"
+      "depTypeTemplate": "apm"
     },
     {
       "description": "Update marketplace APM entries pinned to branches.",
@@ -38,8 +37,7 @@
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{packageName}}}.git",
       "depNameTemplate": "{{{packageName}}}/{{{apmSubdir}}}",
-      "depTypeTemplate": "apm",
-      "autoReplaceStringTemplate": "{{{depPrefix}}}{{{newDigest}}}  # {{{currentValue}}}"
+      "depTypeTemplate": "apm"
     }
   ],
   "packageRules": [

--- a/apm.json
+++ b/apm.json
@@ -19,7 +19,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
       "matchStrings": [
-        "(?<depPrefix>-[^\\S\\n]+name:[^\\S\\n]+[^\\n]+\\n[^\\S\\n]+source:[^\\S\\n]+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n[^\\S\\n]+subdir:[^\\S\\n]+(?<apmSubdir>[^\\n]+)\\n[^\\S\\n]+ref:[^\\S\\n]+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>v?\\d+\\.\\d+\\.\\d+[A-Za-z0-9_.+-]*)"
+        "(?:-[^\\S\\n]+name:[^\\S\\n]+[^\\n]+\\n[^\\S\\n]+source:[^\\S\\n]+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n[^\\S\\n]+subdir:[^\\S\\n]+(?<apmSubdir>[^\\n]+)\\n[^\\S\\n]+ref:[^\\S\\n]+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>v?\\d+\\.\\d+\\.\\d+[A-Za-z0-9_.+-]*)"
       ],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver",
@@ -32,7 +32,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)apm\\.yml$/"],
       "matchStrings": [
-        "(?<depPrefix>-[^\\S\\n]+name:[^\\S\\n]+[^\\n]+\\n[^\\S\\n]+source:[^\\S\\n]+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n[^\\S\\n]+subdir:[^\\S\\n]+(?<apmSubdir>[^\\n]+)\\n[^\\S\\n]+ref:[^\\S\\n]+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[A-UW-Za-uw-z][A-Za-z0-9_./-]*|[vV][A-Za-z_/-][A-Za-z0-9_./-]*)"
+        "(?:-[^\\S\\n]+name:[^\\S\\n]+[^\\n]+\\n[^\\S\\n]+source:[^\\S\\n]+(?<packageName>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\\n[^\\S\\n]+subdir:[^\\S\\n]+(?<apmSubdir>[^\\n]+)\\n[^\\S\\n]+ref:[^\\S\\n]+)(?<currentDigest>[0-9a-f]{40})\\s+#\\s+(?<currentValue>[A-UW-Za-uw-z][A-Za-z0-9_./-]*|[vV][A-Za-z_/-][A-Za-z0-9_./-]*)"
       ],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{packageName}}}.git",


### PR DESCRIPTION
## Why

After #26, grouped APM marketplace updates fail with `depName mismatch`. The replacement templates reference `depPrefix`, but Renovate does not retain arbitrary regex captures in runtime dependency data, so an update removes the matched YAML block before validation.

## What

- Use Renovate's default replacement within the complete marketplace match for both release and branch refs.
- Remove the unused `depPrefix` captures from the marketplace regexes.
- Model the regex manager's extracted fields and require all three dependencies in the grouped regression fixture.
- Document how dependency and marketplace tag and branch references are updated.

This keeps the release discovery, branch tracking, SHA pins, and manual-review policy introduced by #26.

## How to verify

- `node .github/scripts/validate-apm-regex.mjs`
- `node .github/scripts/test-presets.mjs`
- `docker run --rm -v "$PWD":/work -w /work renovate/renovate:44.12.0 renovate-config-validator --strict --no-global apm.json renovate.json`
- Run Renovate 44.12.0 with `dryRun=full` against `Netcracker/qubership-ai-packages`; all eight APM updates reach the simulated branch commit without `depName mismatch` or `update failure`.
