### PR TITLE
fix: unblock dependency updates without timestamps

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -467,6 +467,69 @@ function assertOrgInheritedPolicy(config) {
     true,
     'A later repository rule must be able to re-enable the Action after a compatible release is available'
   );
+
+  const pinDigest = applyPackageRules(
+    {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      packageName: 'alpine',
+      updateType: 'pinDigest',
+    },
+    config.packageRules
+  );
+  assert.equal(pinDigest.minimumReleaseAge, null, 'Pinning a mutable reference must not wait for a release timestamp');
+
+  const versionPin = applyPackageRules(
+    {
+      manager: 'npm',
+      datasource: 'npm',
+      packageName: 'example-package',
+      updateType: 'pin',
+    },
+    config.packageRules
+  );
+  assert.equal(
+    versionPin.minimumReleaseAgeBehaviour,
+    'timestamp-optional',
+    'Version pins must proceed when Renovate cannot attach a release timestamp'
+  );
+
+  const dockerDigest = applyPackageRules(
+    {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      packageName: 'alpine',
+      updateType: 'digest',
+    },
+    config.packageRules
+  );
+  assert.equal(
+    dockerDigest.minimumReleaseAgeBehaviour,
+    'timestamp-optional',
+    'Docker digest updates must proceed when their registry does not provide a release timestamp'
+  );
+
+  for (const dependency of [
+    {
+      manager: 'npm',
+      datasource: 'npm',
+      packageName: 'example-package',
+      updateType: 'patch',
+    },
+    {
+      manager: 'gomod',
+      datasource: 'go',
+      packageName: 'example.com/module',
+      updateType: 'digest',
+    },
+  ]) {
+    const result = applyPackageRules(dependency, config.packageRules);
+    assert.equal(
+      result.minimumReleaseAgeBehaviour,
+      undefined,
+      `${dependency.datasource} ${dependency.updateType} updates must retain the timestamp-required default`
+    );
+  }
 }
 
 function assertAnnotatedVersions(config) {

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -468,16 +468,24 @@ function assertOrgInheritedPolicy(config) {
     'A later repository rule must be able to re-enable the Action after a compatible release is available'
   );
 
-  const pinDigest = applyPackageRules(
-    {
-      manager: 'dockerfile',
-      datasource: 'docker',
-      packageName: 'alpine',
-      updateType: 'pinDigest',
-    },
-    config.packageRules
-  );
-  assert.equal(pinDigest.minimumReleaseAge, null, 'Pinning a mutable reference must not wait for a release timestamp');
+  // Renovate normalizes "0 days" to null before applying package rules. Keep the pinDigest rule last so this
+  // raw-rule merger also verifies policy precedence and catches a future inherited rule that restores the delay.
+  for (const packageName of ['alpine', 'ghcr.io/netcracker/example']) {
+    const pinDigest = applyPackageRules(
+      {
+        manager: 'dockerfile',
+        datasource: 'docker',
+        packageName,
+        updateType: 'pinDigest',
+      },
+      config.packageRules
+    );
+    assert.equal(
+      pinDigest.minimumReleaseAge,
+      null,
+      `Pinning ${packageName} must not wait for a release timestamp`
+    );
+  }
 
   const versionPin = applyPackageRules(
     {

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Repository-local settings win on conflicts. Example:
 }
 ```
 
+The pin and digest exceptions are package rules.
+Use later repository package rules to restore stricter checks.
+A top-level `minimumReleaseAgeBehaviour` value does not override a matching inherited package rule.
+
 To opt a repository out entirely, set `"enabled": false` (or remove the Mend installation from that repo).
 
 ## `default.json` preset

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ for every repository in the organization.
 - `minimumReleaseAge: "7 days"` delays updates until a release has been public for one week.
 - `internalChecksFilter: "strict"` proposes the latest mature version while a newer release is still inside the
   release-age window.
+- Version pins may proceed when Renovate cannot attach a release timestamp.
+- Track this limitation in [Renovate issue #40288](https://github.com/renovatebot/renovate/issues/40288).
+- Docker digest updates still wait seven days when a registry provides a timestamp but may proceed when it does not.
+- Digest pinning proceeds immediately because it only freezes a mutable reference already in use.
 - `osvVulnerabilityAlerts: true` enables OSV.dev in addition to GitHub Security Advisories.
 - Security updates bypass the seven-day delay. The `vulnerabilityAlerts` block opens vulnerability PRs immediately.
 - Go toolchain and official `golang.org/x/*` updates bypass the delay. Other Go module dependencies keep the standard

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -22,11 +22,6 @@
       "enabled": false
     },
     {
-      "description": ["Do not delay pinning mutable references"],
-      "matchUpdateTypes": ["pinDigest"],
-      "minimumReleaseAge": null
-    },
-    {
       "description": ["Allow version pins when Renovate cannot attach a release timestamp"],
       "matchUpdateTypes": ["pin"],
       "minimumReleaseAgeBehaviour": "timestamp-optional"
@@ -77,6 +72,11 @@
       "matchDatasources": ["go"],
       "matchPackageNames": ["golang.org/x/**"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": ["Do not delay pinning mutable references; keep last to override inherited release-age rules"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
     }
   ]
 }

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -22,6 +22,22 @@
       "enabled": false
     },
     {
+      "description": ["Do not delay pinning mutable references"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": ["Allow version pins when Renovate cannot attach a release timestamp"],
+      "matchUpdateTypes": ["pin"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
+      "description": ["Allow Docker digest updates when the registry does not provide a release timestamp"],
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
       "description": ["Group all actions/* GitHub Actions into a single PR"],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/**"],


### PR DESCRIPTION
## Why

The organization requires a seven-day release age. Renovate cannot attach timestamps to version pins, and GHCR, Quay, and ECR do not expose timestamps for Docker digests. Their updates therefore remain blocked indefinitely by renovate/stability-days.

## What

- Allow version pins when Renovate cannot attach a release timestamp.
- Allow Docker digest updates without a timestamp while preserving the seven-day delay when one exists.
- Exempt pinDigest updates because they freeze an existing mutable reference instead of selecting a new release.
- Document and test the exceptions.

This changes inherited behavior across the Netcracker organization. Ordinary version updates keep the seven-day delay. See renovatebot/renovate#40288 and the Renovate Minimum Release Age documentation.

## How to verify

- Run the strict Renovate validator for all JSON configurations.
- Run node .github/scripts/test-presets.mjs.
- Run node .github/scripts/validate-apm-regex.mjs.