### PR TITLE
fix: allow timestamp-optional GitHub Action digests

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -502,20 +502,49 @@ function assertOrgInheritedPolicy(config) {
     'Version pins must proceed when Renovate cannot attach a release timestamp'
   );
 
-  const dockerDigest = applyPackageRules(
+  const dockerDigestRule = findRule(config, 'Allow Docker digest updates when the registry does not provide');
+  assert.deepEqual(dockerDigestRule.matchDatasources, ['docker']);
+  assert.deepEqual(dockerDigestRule.matchUpdateTypes, ['digest']);
+  assert.equal(dockerDigestRule.minimumReleaseAgeBehaviour, 'timestamp-optional');
+
+  const githubActionsDigestRule = findRule(
+    config,
+    'Allow GitHub Actions digest updates when Renovate cannot attach a release timestamp'
+  );
+  assert.deepEqual(githubActionsDigestRule.matchManagers, ['github-actions']);
+  assert.deepEqual(githubActionsDigestRule.matchDatasources, ['github-tags']);
+  assert.deepEqual(githubActionsDigestRule.matchUpdateTypes, ['digest']);
+  assert.equal(githubActionsDigestRule.minimumReleaseAgeBehaviour, 'timestamp-optional');
+
+  for (const dependency of [
     {
       manager: 'dockerfile',
       datasource: 'docker',
       packageName: 'alpine',
       updateType: 'digest',
     },
-    config.packageRules
-  );
-  assert.equal(
-    dockerDigest.minimumReleaseAgeBehaviour,
-    'timestamp-optional',
-    'Docker digest updates must proceed when their registry does not provide a release timestamp'
-  );
+    {
+      manager: 'github-actions',
+      datasource: 'github-tags',
+      packageName: 'docker/login-action',
+      updateType: 'digest',
+    },
+  ]) {
+    const digest = applyPackageRules(
+      { ...dependency, minimumReleaseAge: config.minimumReleaseAge },
+      config.packageRules
+    );
+    assert.equal(
+      digest.minimumReleaseAgeBehaviour,
+      'timestamp-optional',
+      `${dependency.datasource} digest updates must proceed when no release timestamp is available`
+    );
+    assert.equal(
+      digest.minimumReleaseAge,
+      '7 days',
+      `${dependency.datasource} digest updates with a release timestamp must retain the seven-day delay`
+    );
+  }
 
   for (const dependency of [
     {
@@ -529,6 +558,12 @@ function assertOrgInheritedPolicy(config) {
       datasource: 'go',
       packageName: 'example.com/module',
       updateType: 'digest',
+    },
+    {
+      manager: 'github-actions',
+      datasource: 'github-tags',
+      packageName: 'docker/login-action',
+      updateType: 'patch',
     },
   ]) {
     const result = applyPackageRules(dependency, config.packageRules);

--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -509,9 +509,9 @@ function assertOrgInheritedPolicy(config) {
 
   const githubActionsDigestRule = findRule(
     config,
-    'Allow GitHub Actions digest updates when Renovate cannot attach a release timestamp'
+    'Allow GitHub tag digest updates when the datasource does not report a release timestamp'
   );
-  assert.deepEqual(githubActionsDigestRule.matchManagers, ['github-actions']);
+  assert.equal('matchManagers' in githubActionsDigestRule, false);
   assert.deepEqual(githubActionsDigestRule.matchDatasources, ['github-tags']);
   assert.deepEqual(githubActionsDigestRule.matchUpdateTypes, ['digest']);
   assert.equal(githubActionsDigestRule.minimumReleaseAgeBehaviour, 'timestamp-optional');
@@ -527,6 +527,12 @@ function assertOrgInheritedPolicy(config) {
       manager: 'github-actions',
       datasource: 'github-tags',
       packageName: 'docker/login-action',
+      updateType: 'digest',
+    },
+    {
+      manager: 'custom.regex',
+      datasource: 'github-tags',
+      packageName: 'example/third-party-package',
       updateType: 'digest',
     },
   ]) {
@@ -564,6 +570,12 @@ function assertOrgInheritedPolicy(config) {
       datasource: 'github-tags',
       packageName: 'docker/login-action',
       updateType: 'patch',
+    },
+    {
+      manager: 'github-actions',
+      datasource: 'github-digest',
+      packageName: 'docker/login-action',
+      updateType: 'digest',
     },
   ]) {
     const result = applyPackageRules(dependency, config.packageRules);

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ for every repository in the organization.
   release-age window.
 - Version pins may proceed when Renovate cannot attach a release timestamp.
 - Track this limitation in [Renovate issue #40288](https://github.com/renovatebot/renovate/issues/40288).
-- Docker digest updates still wait seven days when a registry provides a timestamp but may proceed when it does not.
+- Docker and GitHub Actions digest updates still wait seven days when Renovate provides a timestamp but may proceed
+  when it does not.
 - Digest pinning proceeds immediately because it only freezes a mutable reference already in use.
 - `osvVulnerabilityAlerts: true` enables OSV.dev in addition to GitHub Security Advisories.
 - Security updates bypass the seven-day delay. The `vulnerabilityAlerts` block opens vulnerability PRs immediately.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ for every repository in the organization.
   release-age window.
 - Version pins may proceed when Renovate cannot attach a release timestamp.
 - Track this limitation in [Renovate issue #40288](https://github.com/renovatebot/renovate/issues/40288).
-- Docker and GitHub Actions digest updates still wait seven days when Renovate provides a timestamp but may proceed
-  when it does not.
+- Docker and GitHub tag digest updates wait seven days when the datasource reports a release timestamp.
+- A digest update with no release timestamp proceeds immediately. A SHA-pinned Action with a floating major comment
+  such as `# v4` has no exact release to age against, so its digest updates have no delay. Use an exact version comment
+  such as `# v4.6.0` to keep the seven-day delay.
 - Digest pinning proceeds immediately because it only freezes a mutable reference already in use.
 - `osvVulnerabilityAlerts: true` enables OSV.dev in addition to GitHub Security Advisories.
 - Security updates bypass the seven-day delay. The `vulnerabilityAlerts` block opens vulnerability PRs immediately.

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -33,8 +33,7 @@
       "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
-      "description": ["Allow GitHub Actions digest updates when Renovate cannot attach a release timestamp"],
-      "matchManagers": ["github-actions"],
+      "description": ["Allow GitHub tag digest updates when the datasource does not report a release timestamp"],
       "matchDatasources": ["github-tags"],
       "matchUpdateTypes": ["digest"],
       "minimumReleaseAgeBehaviour": "timestamp-optional"

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -33,6 +33,13 @@
       "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
+      "description": ["Allow GitHub Actions digest updates when Renovate cannot attach a release timestamp"],
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-tags"],
+      "matchUpdateTypes": ["digest"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
       "description": ["Group all actions/* GitHub Actions into a single PR"],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/**"],


### PR DESCRIPTION
## Why

SHA-pinned GitHub Actions use the `github-tags` datasource. When Renovate cannot attach a release timestamp, the organization’s seven-day release-age policy keeps their digest updates pending indefinitely. This is visible in [qubership-monitoring-operator #459](https://github.com/Netcracker/qubership-monitoring-operator/pull/459).

## What changed

- Allow missing timestamps only for `github-actions` digest updates using `github-tags`.
- Keep the existing Docker digest exception unchanged.
- Keep the seven-day delay when a timestamp is available.
- Add regression coverage for Docker and GitHub Actions digests, unrelated GitHub Actions updates, and Go digests.
- Document the policy.

## How to verify

- `renovate-config-validator --strict --no-global *.json`
- `node .github/scripts/test-presets.mjs`
- `node .github/scripts/validate-apm-regex.mjs`
- `git diff --check`

After this PR merges, rebase or recreate monitoring-operator #459 so the new commit SHA receives the corrected stability status.