### PR TITLE
fix(go): update explicit Alpine builder tags

### DIFF
--- a/.github/scripts/test-presets.mjs
+++ b/.github/scripts/test-presets.mjs
@@ -189,10 +189,11 @@ function assertGoPolicy(config) {
     'Group Go toolchain versions',
     'Group explicit GitHub Actions Go versions with Go toolchain updates',
     'Group official Go builder images with Go toolchain updates',
+    'Update explicit Go and Alpine builder versions together',
   ]) {
     findRule(config, description);
   }
-  assert.equal(config.packageRules.length, 6, 'go.json must not group unrelated Go dependencies');
+  assert.equal(config.packageRules.length, 7, 'go.json must not group unrelated Go dependencies');
   const kubernetes = findRule(config, 'Group Kubernetes Go modules');
   assert.deepEqual(kubernetes.matchPackageNames, [
     'k8s.io/**',
@@ -231,6 +232,7 @@ function assertGoPolicy(config) {
   const builderImage = findRule(config, 'Group official Go builder images with Go toolchain updates');
   for (const depName of [
     'golang',
+    'library/golang',
     'docker.io/library/golang',
     'index.docker.io/library/golang',
     'registry-1.docker.io/library/golang',
@@ -254,6 +256,52 @@ function assertGoPolicy(config) {
     }),
     false,
     'Unrelated Docker images must stay outside the Go toolchain group'
+  );
+
+  const explicitAlpineBuilder = findRule(config, 'Update explicit Go and Alpine builder versions together');
+  assert.equal(
+    explicitAlpineBuilder.versioning,
+    'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-alpine3\\.(?<build>\\d+)$'
+  );
+  for (const packageName of [
+    'golang',
+    'library/golang',
+    'docker.io/library/golang',
+    'index.docker.io/library/golang',
+    'registry-1.docker.io/library/golang',
+  ]) {
+    assert.equal(
+      ruleMatchesDependency(explicitAlpineBuilder, {
+        manager: 'dockerfile',
+        datasource: 'docker',
+        packageName,
+        currentValue: '1.26.4-alpine3.22',
+      }),
+      true,
+      `The explicit ${packageName} Alpine version must be eligible for synchronized updates`
+    );
+  }
+  for (const currentValue of ['1.26.6-alpine', '1.26.6-bookworm', '1.26.6-alpine4.0']) {
+    assert.equal(
+      ruleMatchesDependency(explicitAlpineBuilder, {
+        manager: 'dockerfile',
+        datasource: 'docker',
+        packageName: 'golang',
+        currentValue,
+      }),
+      false,
+      `${currentValue} must retain the default Docker versioning policy`
+    );
+  }
+  assert.equal(
+    ruleMatchesDependency(explicitAlpineBuilder, {
+      manager: 'dockerfile',
+      datasource: 'docker',
+      packageName: 'alpine',
+      currentValue: '3.22',
+    }),
+    false,
+    'The rule must not change unrelated Docker images'
   );
 }
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ a team-specific preset:
 - `github-actions` groups third-party and Netcracker actions separately, with major updates in separate groups.
 - `go` groups Kubernetes and OpenShift, OpenTelemetry, Prometheus, and Go toolchain updates. Toolchain updates include
   `go.mod` directives, explicit GitHub Actions Go versions, and official `golang` builder images. The preset does not
-  group unrelated dependencies or the `actions/setup-go` action version.
+  group unrelated dependencies or the `actions/setup-go` action version. For explicit builder tags such as
+  `1.26.5-alpine3.24`, it updates the Go and Alpine 3 versions together while retaining the explicit Alpine version.
+  Generic Alpine tags and other image variants keep Renovate's default Docker versioning behavior.
 - `go-catch-all` groups minor and patch updates for Go modules not covered by the `go` or `netcracker-dependencies`
   presets. Major updates remain separate.
 - `go-tidy` runs `go mod tidy` after Go module updates.

--- a/go.json
+++ b/go.json
@@ -38,11 +38,26 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "golang",
+        "library/golang",
         "docker.io/library/golang",
         "index.docker.io/library/golang",
         "registry-1.docker.io/library/golang"
       ],
       "groupName": "Go toolchain"
+    },
+    {
+      "description": ["Update explicit Go and Alpine builder versions together"],
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "golang",
+        "library/golang",
+        "docker.io/library/golang",
+        "index.docker.io/library/golang",
+        "registry-1.docker.io/library/golang"
+      ],
+      "matchCurrentValue": "/^\\d+\\.\\d+\\.\\d+-alpine3\\.\\d+$/",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-alpine3\\.(?<build>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate treats the suffix in `golang:1.26.4-alpine3.22` as a compatibility constraint. When Docker Library stops publishing that exact Alpine variant, Go builder updates stop even though newer explicit Alpine variants exist.

This affects [network-latency-exporter#190](https://github.com/Netcracker/qubership-network-latency-exporter/pull/190) and other repositories that still use `alpine3.22`. Switching to the floating `-alpine` alias would hide Alpine version changes from dependency reviews.

## What

- Add narrow regex versioning for official `golang` images in Dockerfiles whose current tag matches `X.Y.Z-alpine3.N`.
- Update Go and Alpine 3 versions while retaining an explicit Alpine suffix and digest.
- Keep generic Alpine tags, Debian variants, Alpine 4, other images, and non-Dockerfile managers on Renovate's default behavior.
- Document the behavior and add regression coverage for matching and excluded values.

## How to verify

- Run `node .github/scripts/test-presets.mjs`.
- Run `node .github/scripts/validate-apm-regex.mjs`.
- Run the strict Renovate config validator for all shared configs and `renovate.json`.
- Run a Renovate 44.11 lookup for `1.26.4-alpine3.22` and verify that it selects `1.26.6-alpine3.24` with its digest.
